### PR TITLE
chore: upgrade farzai/transport to v2.1

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.2, 8.1]
+        php: [8.3, 8.2]
         stability: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,11 +9,8 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.5, 8.4, 8.3, 8.2]
+        php: [8.4, 8.3, 8.2]
         stability: [prefer-lowest, prefer-stable]
-        exclude:
-          - php: 8.5
-            stability: prefer-lowest
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.3, 8.2]
+        php: [8.5, 8.4, 8.3, 8.2]
         stability: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,6 +11,9 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         php: [8.5, 8.4, 8.3, 8.2]
         stability: [prefer-lowest, prefer-stable]
+        exclude:
+          - php: 8.5
+            stability: prefer-lowest
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.fleet
 .php_cs
 .php_cs.cache
+.phpunit.cache
 .phpunit.result.cache
 build
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,11 @@
     "require": {
         "php": "^8.1",
         "farzai/support": "^1.2",
-        "farzai/transport": "^1.2",
+        "farzai/transport": "^2.1",
         "phrity/websocket": "^3.0"
     },
     "require-dev": {
+        "guzzlehttp/guzzle": "^7.8",
         "pestphp/pest": "^2.15",
         "laravel/pint": "^1.0",
         "spatie/ray": "^1.28"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "farzai/support": "^1.2",
         "farzai/transport": "^2.1",
         "phrity/websocket": "^3.0"

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -41,7 +41,7 @@ final class ClientBuilder
      */
     public static function create()
     {
-        return new self();
+        return new self;
     }
 
     /**
@@ -98,7 +98,7 @@ final class ClientBuilder
     {
         $this->ensureConfigIsValid();
 
-        $logger = $this->logger ?? new NullLogger();
+        $logger = $this->logger ?? new NullLogger;
 
         $builder = TransportBuilder::make()
             ->withBaseUri(sprintf('https://%s', self::DEFAULT_HOST))
@@ -130,8 +130,5 @@ final class ClientBuilder
         }
     }
 
-    final public function __construct()
-    {
-
-    }
+    final public function __construct() {}
 }

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -100,15 +100,15 @@ final class ClientBuilder
 
         $logger = $this->logger ?? new NullLogger();
 
-        $builder = TransportBuilder::make();
+        $builder = TransportBuilder::make()
+            ->withBaseUri(sprintf('https://%s', self::DEFAULT_HOST))
+            ->setLogger($logger);
+
         if ($this->httpClient) {
-            $builder->setClient($this->httpClient);
+            $builder = $builder->setClient($this->httpClient);
         }
 
-        $builder->setLogger($logger);
-
         $transport = $builder->build();
-        $transport->setUri(sprintf('https://%s', self::DEFAULT_HOST));
 
         $client = new Client(
             config: $this->config,

--- a/src/Endpoints/MarketEndpoint.php
+++ b/src/Endpoints/MarketEndpoint.php
@@ -35,7 +35,7 @@ class MarketEndpoint extends AbstractEndpoint
     /**
      * Get ticker information.
      *
-     * @param  string  $symbol (optional) The symbol (e.g. btc_thb)
+     * @param  string  $symbol  (optional) The symbol (e.g. btc_thb)
      *
      * @response
      * {
@@ -388,7 +388,7 @@ class MarketEndpoint extends AbstractEndpoint
      * List all open orders of the given symbol.
      * Note : The client_id of this API response is the input body field name client_id , was inputted by the user of APIs.
      *
-     * @param  string  $sym The symbol (e.g. btc_thb)
+     * @param  string  $sym  The symbol (e.g. btc_thb)
      *
      * @response
      * {

--- a/src/Requests/PendingRequest.php
+++ b/src/Requests/PendingRequest.php
@@ -6,7 +6,7 @@ use Farzai\Bitkub\Contracts\ClientInterface;
 use Farzai\Bitkub\Contracts\RequestInterceptor;
 use Farzai\Bitkub\Responses\ResponseWithValidateErrorCode;
 use Farzai\Transport\Contracts\ResponseInterface;
-use Farzai\Transport\Request;
+use Farzai\Transport\RequestBuilder;
 use Farzai\Transport\Response;
 use Psr\Http\Message\RequestInterface as PsrRequestInterface;
 use Psr\Http\Message\ResponseInterface as PsrResponseInterface;
@@ -146,25 +146,27 @@ class PendingRequest
         // Normalize path
         $path = '/'.trim($path, '/');
 
+        $builder = (new RequestBuilder)->method($method)->uri($path);
+
         // Query
         if (isset($options['query']) && is_array($options['query']) && ! empty($options['query'])) {
-            $path .= '?'.http_build_query($options['query']);
+            $builder = $builder->withQuery($options['query']);
         }
 
         // Set body
         if (isset($options['body'])) {
             $body = $options['body'];
-
-            // Convert array to json
-            if (is_array($body)) {
-                $body = json_encode($body);
-            }
+            $builder = is_array($body)
+                ? $builder->withJson($body)
+                : $builder->withBody($body);
         }
 
         // Set headers
-        $headers = $options['headers'] ?? [];
+        if (! empty($options['headers'])) {
+            $builder = $builder->withHeaders($options['headers']);
+        }
 
-        return new Request($method, $path, $headers, $body ?? null);
+        return $builder->build();
     }
 
     /**

--- a/src/Responses/AbstractResponseDecorator.php
+++ b/src/Responses/AbstractResponseDecorator.php
@@ -3,13 +3,11 @@
 namespace Farzai\Bitkub\Responses;
 
 use Farzai\Transport\Contracts\ResponseInterface;
-use Farzai\Transport\Traits\PsrResponseTrait;
 use Psr\Http\Message\RequestInterface as PsrRequestInterface;
+use Psr\Http\Message\StreamInterface;
 
 abstract class AbstractResponseDecorator implements ResponseInterface
 {
-    use PsrResponseTrait;
-
     protected ResponseInterface $response;
 
     /**
@@ -45,11 +43,11 @@ abstract class AbstractResponseDecorator implements ResponseInterface
     }
 
     /**
-     * Check if the response is successfull.
+     * Check if the response is successful.
      */
-    public function isSuccessfull(): bool
+    public function isSuccessful(): bool
     {
-        return $this->response->isSuccessfull();
+        return $this->response->isSuccessful();
     }
 
     /**
@@ -61,15 +59,31 @@ abstract class AbstractResponseDecorator implements ResponseInterface
     }
 
     /**
-     * Throw an exception if the response is not successfull.
-     *
-     * @param  callable<\Farzai\Transport\Contracts\ResponseInterface>  $callback Custom callback to throw an exception.
+     * Return the json decoded response or null.
+     */
+    public function jsonOrNull(?string $key = null): mixed
+    {
+        return $this->response->jsonOrNull($key);
+    }
+
+    /**
+     * Return the response as an array.
+     */
+    public function toArray(): array
+    {
+        return $this->response->toArray();
+    }
+
+    /**
+     * Throw an exception if the response is not successful.
      *
      * @throws \Psr\Http\Client\ClientExceptionInterface
      */
-    public function throw(?callable $callback = null)
+    public function throw(?callable $callback = null): static
     {
-        return $this->response->throw($callback);
+        $this->response->throw($callback);
+
+        return $this;
     }
 
     /**
@@ -78,5 +92,85 @@ abstract class AbstractResponseDecorator implements ResponseInterface
     public function getPsrRequest(): PsrRequestInterface
     {
         return $this->response->getPsrRequest();
+    }
+
+    // PSR-7 ResponseInterface delegation
+
+    public function getStatusCode(): int
+    {
+        return $this->response->getStatusCode();
+    }
+
+    public function withStatus(int $code, string $reasonPhrase = ''): static
+    {
+        return $this->cloneWithResponse($this->response->withStatus($code, $reasonPhrase));
+    }
+
+    public function getReasonPhrase(): string
+    {
+        return $this->response->getReasonPhrase();
+    }
+
+    public function getProtocolVersion(): string
+    {
+        return $this->response->getProtocolVersion();
+    }
+
+    public function withProtocolVersion(string $version): static
+    {
+        return $this->cloneWithResponse($this->response->withProtocolVersion($version));
+    }
+
+    public function getHeaders(): array
+    {
+        return $this->response->getHeaders();
+    }
+
+    public function hasHeader(string $name): bool
+    {
+        return $this->response->hasHeader($name);
+    }
+
+    public function getHeader(string $name): array
+    {
+        return $this->response->getHeader($name);
+    }
+
+    public function getHeaderLine(string $name): string
+    {
+        return $this->response->getHeaderLine($name);
+    }
+
+    public function withHeader(string $name, $value): static
+    {
+        return $this->cloneWithResponse($this->response->withHeader($name, $value));
+    }
+
+    public function withAddedHeader(string $name, $value): static
+    {
+        return $this->cloneWithResponse($this->response->withAddedHeader($name, $value));
+    }
+
+    public function withoutHeader(string $name): static
+    {
+        return $this->cloneWithResponse($this->response->withoutHeader($name));
+    }
+
+    public function getBody(): StreamInterface
+    {
+        return $this->response->getBody();
+    }
+
+    public function withBody(StreamInterface $body): static
+    {
+        return $this->cloneWithResponse($this->response->withBody($body));
+    }
+
+    private function cloneWithResponse(ResponseInterface $response): static
+    {
+        $clone = clone $this;
+        $clone->response = $response;
+
+        return $clone;
     }
 }

--- a/src/Responses/ResponseWithValidateErrorCode.php
+++ b/src/Responses/ResponseWithValidateErrorCode.php
@@ -8,19 +8,22 @@ use Farzai\Transport\Contracts\ResponseInterface;
 class ResponseWithValidateErrorCode extends AbstractResponseDecorator
 {
     /**
-     * Throw an exception if the response is not successfull.
+     * Throw an exception if the response is not successful.
      *
      *
      * @throws \Psr\Http\Client\ClientExceptionInterface
      */
-    public function throw(?callable $callback = null)
+    public function throw(?callable $callback = null): static
     {
-        return parent::throw($callback ?? function (ResponseInterface $response, ?\Exception $e) use ($callback) {
-            if ($this->json('error') !== null && $this->json('error') !== 0) {
+        parent::throw($callback ?? function (ResponseInterface $response, ?\Exception $e) use ($callback) {
+            $errorCode = $this->json('error');
+            if ($errorCode !== null && $errorCode !== 0) {
                 throw new BitkubResponseErrorCodeException($response);
             }
 
             return $callback ? $callback($response, $e) : $response;
         });
+
+        return $this;
     }
 }

--- a/src/WebSocket/Endpoints/LiveOrderBookEndpoint.php
+++ b/src/WebSocket/Endpoints/LiveOrderBookEndpoint.php
@@ -13,7 +13,7 @@ class LiveOrderBookEndpoint extends AbstractEndpoint
      *    echo $message->json('sym');
      * });
      *
-     * @param  string|int  $symbol Symbol name or id.
+     * @param  string|int  $symbol  Symbol name or id.
      * @param  callable|array<callable>  $listeners
      */
     public function listen($symbol, $listeners)

--- a/src/WebSocket/Engine.php
+++ b/src/WebSocket/Engine.php
@@ -14,8 +14,7 @@ class Engine implements WebSocketEngineInterface
 {
     public function __construct(
         private LoggerInterface $logger,
-    ) {
-    }
+    ) {}
 
     public function handle(array $listeners): void
     {
@@ -28,8 +27,8 @@ class Engine implements WebSocketEngineInterface
         $client = new WebSocketClient('wss://api.bitkub.com/websocket-api/'.implode(',', $events));
 
         $client
-            ->addMiddleware(new WebSocketMiddleware\CloseHandler())
-            ->addMiddleware(new WebSocketMiddleware\PingResponder());
+            ->addMiddleware(new WebSocketMiddleware\CloseHandler)
+            ->addMiddleware(new WebSocketMiddleware\PingResponder);
 
         $client->onText(function (WebSocketClient $client, WebSocketConnection $connection, WebSocketMessage $message) use ($listeners) {
             $receivedAt = Carbon::now();

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -26,3 +26,39 @@ it('should throw exception when call method without secret key', function () {
 
     $client->market()->balances();
 })->throws(InvalidArgumentException::class, 'Secret key is required');
+
+it('can set custom http client', function () {
+    $httpClient = $this->createMock(\Psr\Http\Client\ClientInterface::class);
+
+    $client = ClientBuilder::create()
+        ->setCredentials('test', 'secret')
+        ->setHttpClient($httpClient)
+        ->build();
+
+    expect($client)->toBeInstanceOf(Client::class);
+});
+
+it('can set custom logger', function () {
+    $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+
+    $client = ClientBuilder::create()
+        ->setCredentials('test', 'secret')
+        ->setLogger($logger)
+        ->build();
+
+    expect($client)->toBeInstanceOf(Client::class);
+});
+
+it('can set retries', function () {
+    $client = ClientBuilder::create()
+        ->setCredentials('test', 'secret')
+        ->setRetries(5)
+        ->build();
+
+    expect($client)->toBeInstanceOf(Client::class);
+});
+
+it('should throw exception when retries is negative', function () {
+    ClientBuilder::create()
+        ->setRetries(-1);
+})->throws(\InvalidArgumentException::class, 'Retries must be greater than or equal to 0.');

--- a/tests/PendingRequestTest.php
+++ b/tests/PendingRequestTest.php
@@ -149,3 +149,62 @@ it('it can createRequest success', function () {
     expect($request->getUri()->getQuery())->toBe('symbol=BTC');
     expect($request->getHeaderLine('Content-Type'))->toBe('application/json');
 });
+
+it('can createRequest with string body', function () {
+    $client = ClientBuilder::create()
+        ->setCredentials('test', 'secret')
+        ->build();
+
+    $pending = new PendingRequest($client, 'POST', '/api/market/orders');
+
+    $request = $pending->createRequest('POST', '/api/market/orders', [
+        'body' => 'raw-string-body',
+    ]);
+
+    expect($request)->toBeInstanceOf(\Psr\Http\Message\RequestInterface::class);
+    expect($request->getBody()->getContents())->toBe('raw-string-body');
+});
+
+it('can createRequest without optional parameters', function () {
+    $client = ClientBuilder::create()
+        ->setCredentials('test', 'secret')
+        ->build();
+
+    $pending = new PendingRequest($client, 'GET', '/api/market/ticker');
+
+    $request = $pending->createRequest('GET', '/api/market/ticker');
+
+    expect($request)->toBeInstanceOf(\Psr\Http\Message\RequestInterface::class);
+    expect($request->getMethod())->toBe('GET');
+    expect($request->getUri()->getPath())->toBe('/api/market/ticker');
+    expect($request->getUri()->getQuery())->toBe('');
+});
+
+it('normalizes path with leading slash', function () {
+    $client = ClientBuilder::create()
+        ->setCredentials('test', 'secret')
+        ->build();
+
+    $pending = new PendingRequest($client, 'GET', 'api/market/ticker');
+
+    $request = $pending->createRequest('GET', 'api/market/ticker');
+
+    expect($request->getUri()->getPath())->toBe('/api/market/ticker');
+});
+
+it('can createResponse wrapping PSR response', function () {
+    $client = ClientBuilder::create()
+        ->setCredentials('test', 'secret')
+        ->build();
+
+    $pending = new PendingRequest($client, 'GET', '/api/market/ticker');
+
+    $psrRequest = $this->createMock(\Psr\Http\Message\RequestInterface::class);
+    $psrResponse = \Farzai\Bitkub\Tests\MockHttpClient::response(200, json_encode(['error' => 0]));
+
+    $response = $pending->createResponse($psrRequest, $psrResponse);
+
+    expect($response)->toBeInstanceOf(\Farzai\Transport\Contracts\ResponseInterface::class);
+    expect($response)->toBeInstanceOf(\Farzai\Bitkub\Responses\ResponseWithValidateErrorCode::class);
+    expect($response->statusCode())->toBe(200);
+});

--- a/tests/ResponseErrorCodeTest.php
+++ b/tests/ResponseErrorCodeTest.php
@@ -27,7 +27,7 @@ it('decorator must be instance of ResponseInterface', function () {
     expect($response->headers())->toBe([
         'Content-Type' => 'application/json',
     ]);
-    expect($response->isSuccessfull())->toBeTrue();
+    expect($response->isSuccessful())->toBeTrue();
     expect($response->json('error'))->toBe(0);
     expect($response->getPsrRequest())->toBe($psrRequest);
 });

--- a/tests/ResponseErrorCodeTest.php
+++ b/tests/ResponseErrorCodeTest.php
@@ -78,3 +78,78 @@ it('should be error code not found', function () {
 
     new BitkubResponseErrorCodeException($psrResponse);
 })->throws(\Exception::class, 'Error code not found.');
+
+it('should not throw exception when error code is null', function () {
+    $psrRequest = $this->createMock(PsrRequestInterface::class);
+    $psrResponse = MockHttpClient::response(200, json_encode([
+        'result' => 'ok',
+    ]));
+
+    $response = new Response($psrRequest, $psrResponse);
+    $response = new ResponseWithValidateErrorCode($response);
+
+    $result = $response->throw();
+
+    expect($result)->toBeInstanceOf(ResponseWithValidateErrorCode::class);
+});
+
+it('throw returns static for chaining', function () {
+    $psrRequest = $this->createMock(PsrRequestInterface::class);
+    $psrResponse = MockHttpClient::response(200, json_encode([
+        'error' => 0,
+    ]));
+
+    $response = new Response($psrRequest, $psrResponse);
+    $response = new ResponseWithValidateErrorCode($response);
+
+    $result = $response->throw();
+
+    expect($result)->toBe($response);
+});
+
+it('decorator delegates jsonOrNull method', function () {
+    $psrRequest = $this->createMock(PsrRequestInterface::class);
+    $psrResponse = MockHttpClient::response(200, json_encode([
+        'error' => 0,
+        'result' => ['balance' => 100],
+    ]));
+
+    $response = new Response($psrRequest, $psrResponse);
+    $response = new ResponseWithValidateErrorCode($response);
+
+    expect($response->jsonOrNull('result'))->toBe(['balance' => 100]);
+    expect($response->jsonOrNull('nonexistent'))->toBeNull();
+});
+
+it('decorator delegates toArray method', function () {
+    $psrRequest = $this->createMock(PsrRequestInterface::class);
+    $psrResponse = MockHttpClient::response(200, json_encode([
+        'error' => 0,
+        'result' => 'ok',
+    ]));
+
+    $response = new Response($psrRequest, $psrResponse);
+    $response = new ResponseWithValidateErrorCode($response);
+
+    expect($response->toArray())->toBe(['error' => 0, 'result' => 'ok']);
+});
+
+it('decorator delegates PSR-7 getStatusCode', function () {
+    $psrRequest = $this->createMock(PsrRequestInterface::class);
+    $psrResponse = MockHttpClient::response(201, json_encode(['error' => 0]));
+
+    $response = new Response($psrRequest, $psrResponse);
+    $response = new ResponseWithValidateErrorCode($response);
+
+    expect($response->getStatusCode())->toBe(201);
+});
+
+it('decorator delegates PSR-7 getBody', function () {
+    $psrRequest = $this->createMock(PsrRequestInterface::class);
+    $psrResponse = MockHttpClient::response(200, json_encode(['error' => 0]));
+
+    $response = new Response($psrRequest, $psrResponse);
+    $response = new ResponseWithValidateErrorCode($response);
+
+    expect($response->getBody())->toBeInstanceOf(\Psr\Http\Message\StreamInterface::class);
+});


### PR DESCRIPTION
## Summary

Upgrade `farzai/transport` from `^1.2` to `^2.1` and migrate the codebase to the new Transport v2 API.

## Changes

- **Dependencies**: Bump `farzai/transport` to `^2.1`, add `guzzlehttp/guzzle` as dev dependency
- **ClientBuilder**: Migrate to new `TransportBuilder` fluent API (`withBaseUri`, `setLogger`)
- **PendingRequest**: Replace deprecated `Request` class with `RequestBuilder`
- **AbstractResponseDecorator**: Remove `PsrResponseTrait`, implement PSR-7 delegation directly, add `jsonOrNull()` and `toArray()` methods
- **ResponseWithValidateErrorCode**: Update `throw()` return type to `static` for proper chaining
- **Typo fix**: Rename `isSuccessfull()` to `isSuccessful()`
- **Config**: Add `.phpunit.cache` to `.gitignore`

## Test plan

- [ ] Verify `composer install` succeeds with updated dependencies
- [ ] Run `vendor/bin/pest` to confirm all tests pass
- [ ] Test API calls against Bitkub endpoints to validate transport layer changes