### PR TITLE
refactor!: enforce strict types, fix API bugs, and add WebSocket builder pattern

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,5 +1,5 @@
 name: dependabot-auto-merge
-on: pull_request
+on: pull_request_target
 
 permissions:
   pull-requests: write

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,5 +1,5 @@
 name: dependabot-auto-merge
-on: pull_request_target
+on: pull_request
 
 permissions:
   pull-requests: write
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
-    
+
       - name: Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v2.5.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          
+
       - name: Auto-merge Dependabot PRs for semver-minor/patch updates
         if: ${{steps.metadata.outputs.update-type != 'version-update:semver-major'}}
         run: gh pr merge --auto --merge "$PR_URL"

--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -2,6 +2,8 @@ name: Fix PHP code style issues
 
 on:
   push:
+    branches:
+      - main
     paths:
       - '**.php'
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 Simplify the integration of the Bitkub API into your PHP application.
 [Bitkub API Documentation](https://github.com/bitkub/bitkub-official-api-docs/blob/master/restful-api.md)
 
+**Requirements:** PHP 8.2+
+
 **Notes**
 We are not affiliated, associated, authorized, endorsed by, or in any way officially connected with Bitkub, or any of its subsidiaries or its affiliates.
 
@@ -43,27 +45,26 @@ $myBTC = $response->json('result.BTC.available');
 echo "My BTC balance: {$myBTC}";
 ```
 
-Websocket API
+WebSocket API
 
 ```php
+$client = \Farzai\Bitkub\ClientBuilder::create()
+    ->setCredentials('YOUR_API_KEY', 'YOUR_SECRET_KEY')
+    ->build();
 
-$websocket = new \Farzai\Bitkub\WebSocket\Endpoints\MarketEndpoint(
-    new \Farzai\Bitkub\WebSocketClient(
-        \Farzai\Bitkub\ClientBuilder::create()
-            ->setCredentials('YOUR_API_KEY', 'YOUR_SECRET_KEY')
-            ->build(),
-    ),
-);
+$websocket = \Farzai\Bitkub\WebSocketClientBuilder::create()
+    ->setClient($client)
+    ->build();
 
-$websocket->listen('trade.thb_ada', function (\Farzai\Bitkub\WebSocket\Message $message) {
+$websocket->market()->listen('trade.thb_ada', function (\Farzai\Bitkub\WebSocket\Message $message) {
     // Do something
-    echo $message->sym.PHP_EOL;
+    echo $message->sym . PHP_EOL;
 });
 
 // Or you can use multiple symbols like this
-$websocket->listen(['trade.thb_ada', 'trade.thb_btc'], function (\Farzai\Bitkub\WebSocket\Message $message) {
+$websocket->market()->listen(['trade.thb_ada', 'trade.thb_btc'], function (\Farzai\Bitkub\WebSocket\Message $message) {
     // Do something
-    echo $message->sym.PHP_EOL;
+    echo $message->sym . PHP_EOL;
 });
 
 $websocket->run();
@@ -104,6 +105,9 @@ $websocket->run();
     - [User](#user)
       - [Check trading credit balance.](#check-trading-credit-balance)
       - [Check deposit/withdraw limitations and usage.](#check-depositwithdraw-limitations-and-usage)
+    - [WebSocket](#websocket)
+      - [Market streams](#market-streams)
+      - [Live order book](#live-order-book)
   - [Testing](#testing)
   - [Changelog](#changelog)
   - [Contributing](#contributing)
@@ -472,6 +476,54 @@ $user->tradingCredits();
 
 ```php
 $user->limits();
+```
+
+### WebSocket
+
+Create a WebSocket client using the `WebSocketClientBuilder`.
+
+```php
+$client = \Farzai\Bitkub\ClientBuilder::create()
+    ->setCredentials('YOUR_API_KEY', 'YOUR_SECRET_KEY')
+    ->build();
+
+$websocket = \Farzai\Bitkub\WebSocketClientBuilder::create()
+    ->setClient($client)
+    ->build();
+```
+
+#### Market streams
+
+Subscribe to market data streams (trades, tickers, etc.).
+
+```php
+$websocket->market()->listen('trade.thb_btc', function (\Farzai\Bitkub\WebSocket\Message $message) {
+    echo $message->sym . PHP_EOL;
+});
+
+// Or subscribe to multiple streams at once
+$websocket->market()->listen(['trade.thb_btc', 'trade.thb_eth'], function (\Farzai\Bitkub\WebSocket\Message $message) {
+    echo $message->sym . PHP_EOL;
+});
+
+$websocket->run();
+```
+
+#### Live order book
+
+Subscribe to live order book updates. Requires a REST client to resolve symbol names.
+
+```php
+$websocket->liveOrderBook()->listen('THB_BTC', function (\Farzai\Bitkub\WebSocket\Message $message) {
+    echo $message . PHP_EOL;
+});
+
+// Or use a numeric symbol ID directly
+$websocket->liveOrderBook()->listen(1, function (\Farzai\Bitkub\WebSocket\Message $message) {
+    echo $message . PHP_EOL;
+});
+
+$websocket->run();
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Simplify the integration of the Bitkub API into your PHP application.
 [Bitkub API Documentation](https://github.com/bitkub/bitkub-official-api-docs/blob/master/restful-api.md)
 
-**Notes
+**Notes**
 We are not affiliated, associated, authorized, endorsed by, or in any way officially connected with Bitkub, or any of its subsidiaries or its affiliates.
 
 ## Installation
@@ -61,7 +61,7 @@ $websocket->listen('trade.thb_ada', function (\Farzai\Bitkub\WebSocket\Message $
 });
 
 // Or you can use multiple symbols like this
-$websocket->listen(['trade.thb_ada', 'trade.thb_btc', function (\Farzai\Bitkub\WebSocket\Message $message) {
+$websocket->listen(['trade.thb_ada', 'trade.thb_btc'], function (\Farzai\Bitkub\WebSocket\Message $message) {
     // Do something
     echo $message->sym.PHP_EOL;
 });
@@ -112,7 +112,7 @@ $websocket->run();
   - [License](#license)
 
 ### Market
-Call the market endpoint. 
+Call the market endpoint.
 This will return an instance of `Farzai\Bitkub\Endpoints\MarketEndpoint` class.
 
 ```php
@@ -192,7 +192,7 @@ $market->books([
 ```
 
 #### Get user available balances
-- GET `/api/market/wallet`
+- POST `/api/v3/market/wallet`
 ```php
 $market->wallet();
 ```
@@ -351,7 +351,7 @@ $crypto->addresses([
 $crypto->withdrawal([
     // string: Currency for withdrawal (e.g. BTC, ETH)
     'cur' => 'BTC',
-    
+
     // float: Amount you want to withdraw
     'amt' => 0.001,
 

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,6 @@
             "phpstan/extension-installer": true
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Farzai\Bitkub;
 
 use Farzai\Bitkub\Contracts\ClientInterface;
@@ -40,24 +42,32 @@ class Client implements ClientInterface
         $this->logger = $logger;
     }
 
+    private ?Endpoints\MarketEndpoint $marketEndpoint = null;
+
+    private ?Endpoints\CryptoEndpoint $cryptoEndpoint = null;
+
+    private ?Endpoints\UserEndpoint $userEndpoint = null;
+
+    private ?Endpoints\SystemEndpoint $systemEndpoint = null;
+
     public function market(): Endpoints\MarketEndpoint
     {
-        return new Endpoints\MarketEndpoint($this);
+        return $this->marketEndpoint ??= new Endpoints\MarketEndpoint($this);
     }
 
     public function crypto(): Endpoints\CryptoEndpoint
     {
-        return new Endpoints\CryptoEndpoint($this);
+        return $this->cryptoEndpoint ??= new Endpoints\CryptoEndpoint($this);
     }
 
     public function user(): Endpoints\UserEndpoint
     {
-        return new Endpoints\UserEndpoint($this);
+        return $this->userEndpoint ??= new Endpoints\UserEndpoint($this);
     }
 
     public function system(): Endpoints\SystemEndpoint
     {
-        return new Endpoints\SystemEndpoint($this);
+        return $this->systemEndpoint ??= new Endpoints\SystemEndpoint($this);
     }
 
     public function getTransport(): Transport

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -38,8 +38,6 @@ final class ClientBuilder
 
     /**
      * Create a new client builder instance.
-     *
-     * @return static
      */
     public static function create(): static
     {

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Farzai\Bitkub;
 
 use Farzai\Bitkub\Exceptions\InvalidArgumentException;
@@ -10,7 +12,7 @@ use Psr\Log\NullLogger;
 
 final class ClientBuilder
 {
-    const DEFAULT_HOST = 'api.bitkub.com';
+    private const DEFAULT_HOST = 'api.bitkub.com';
 
     /**
      * The config.
@@ -32,14 +34,14 @@ final class ClientBuilder
     /**
      * The number of times to retry failed requests.
      */
-    private $retries = 3;
+    private int $retries = 3;
 
     /**
      * Create a new client builder instance.
      *
      * @return static
      */
-    public static function create()
+    public static function create(): static
     {
         return new self;
     }
@@ -49,7 +51,7 @@ final class ClientBuilder
      *
      * @return $this
      */
-    public function setCredentials(string $apiKey, string $secretKey)
+    public function setCredentials(string $apiKey, string $secretKey): static
     {
         $this->config = array_merge($this->config, [
             'api_key' => $apiKey,
@@ -64,7 +66,7 @@ final class ClientBuilder
      *
      * @return $this
      */
-    public function setHttpClient(PsrClientInterface $httpClient)
+    public function setHttpClient(PsrClientInterface $httpClient): static
     {
         $this->httpClient = $httpClient;
 
@@ -76,14 +78,14 @@ final class ClientBuilder
      *
      * @return $this
      */
-    public function setLogger(PsrLoggerInterface $logger)
+    public function setLogger(PsrLoggerInterface $logger): static
     {
         $this->logger = $logger;
 
         return $this;
     }
 
-    public function setRetries(int $retries)
+    public function setRetries(int $retries): static
     {
         if ($retries < 0) {
             throw new \InvalidArgumentException('Retries must be greater than or equal to 0.');
@@ -94,7 +96,7 @@ final class ClientBuilder
         return $this;
     }
 
-    public function build()
+    public function build(): Client
     {
         $this->ensureConfigIsValid();
 

--- a/src/Constants/ErrorCodes.php
+++ b/src/Constants/ErrorCodes.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Farzai\Bitkub\Constants;
 
 class ErrorCodes

--- a/src/Contracts/ClientInterface.php
+++ b/src/Contracts/ClientInterface.php
@@ -1,9 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Farzai\Bitkub\Contracts;
 
 use Farzai\Transport\Transport;
 use Psr\Http\Message\RequestInterface as PsrRequestInterface;
+use Psr\Http\Message\ResponseInterface as PsrResponseInterface;
 use Psr\Log\LoggerInterface;
 
 interface ClientInterface
@@ -26,5 +29,5 @@ interface ClientInterface
     /**
      * Send the request.
      */
-    public function sendRequest(PsrRequestInterface $request);
+    public function sendRequest(PsrRequestInterface $request): PsrResponseInterface;
 }

--- a/src/Contracts/RequestInterceptor.php
+++ b/src/Contracts/RequestInterceptor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Farzai\Bitkub\Contracts;
 
 use Psr\Http\Message\RequestInterface as PsrRequestInterface;

--- a/src/Contracts/WebSocketEngineInterface.php
+++ b/src/Contracts/WebSocketEngineInterface.php
@@ -6,5 +6,10 @@ namespace Farzai\Bitkub\Contracts;
 
 interface WebSocketEngineInterface
 {
+    /**
+     * Handle WebSocket connections and dispatch messages to listeners.
+     *
+     * @param  array<string, array<callable(\Farzai\Bitkub\WebSocket\Message): void>>  $listeners
+     */
     public function handle(array $listeners): void;
 }

--- a/src/Contracts/WebSocketEngineInterface.php
+++ b/src/Contracts/WebSocketEngineInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Farzai\Bitkub\Contracts;
 
 interface WebSocketEngineInterface

--- a/src/Endpoints/AbstractEndpoint.php
+++ b/src/Endpoints/AbstractEndpoint.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Farzai\Bitkub\Endpoints;
 
 use Farzai\Bitkub\Contracts\ClientInterface;

--- a/src/Endpoints/AbstractEndpoint.php
+++ b/src/Endpoints/AbstractEndpoint.php
@@ -16,6 +16,11 @@ abstract class AbstractEndpoint
         $this->client = $client;
     }
 
+    protected function filterParams(array $params): array
+    {
+        return array_filter($params, fn ($value) => $value !== null && $value !== '');
+    }
+
     protected function makeRequest(string $method, string $path, array $options = []): PendingRequest
     {
         return new PendingRequest($this->client, $method, $path, $options);

--- a/src/Endpoints/CryptoEndpoint.php
+++ b/src/Endpoints/CryptoEndpoint.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Farzai\Bitkub\Endpoints;
 
 use Farzai\Bitkub\Requests\GenerateSignatureV3;
@@ -40,7 +42,7 @@ class CryptoEndpoint extends AbstractEndpoint
         $config = $this->client->getConfig();
 
         return $this->makeRequest('GET', '/api/v3/crypto/addresses')
-            ->withQuery(array_filter($params))
+            ->withQuery(array_filter($params, fn ($value) => $value !== null && $value !== ''))
             ->acceptJson()
             ->withInterceptor(new GenerateSignatureV3($config, $this->client))
             ->send();
@@ -173,7 +175,7 @@ class CryptoEndpoint extends AbstractEndpoint
         $config = $this->client->getConfig();
 
         return $this->makeRequest('POST', '/api/v3/crypto/deposit-history')
-            ->withQuery(array_filter($params))
+            ->withQuery(array_filter($params, fn ($value) => $value !== null && $value !== ''))
             ->acceptJson()
             ->withInterceptor(new GenerateSignatureV3($config, $this->client))
             ->send();
@@ -216,7 +218,7 @@ class CryptoEndpoint extends AbstractEndpoint
         $config = $this->client->getConfig();
 
         return $this->makeRequest('POST', '/api/v3/crypto/withdrawal-history')
-            ->withQuery(array_filter($params))
+            ->withQuery(array_filter($params, fn ($value) => $value !== null && $value !== ''))
             ->acceptJson()
             ->withInterceptor(new GenerateSignatureV3($config, $this->client))
             ->send();

--- a/src/Endpoints/CryptoEndpoint.php
+++ b/src/Endpoints/CryptoEndpoint.php
@@ -42,7 +42,7 @@ class CryptoEndpoint extends AbstractEndpoint
         $config = $this->client->getConfig();
 
         return $this->makeRequest('GET', '/api/v3/crypto/addresses')
-            ->withQuery(array_filter($params, fn ($value) => $value !== null && $value !== ''))
+            ->withQuery($this->filterParams($params))
             ->acceptJson()
             ->withInterceptor(new GenerateSignatureV3($config, $this->client))
             ->send();
@@ -175,7 +175,7 @@ class CryptoEndpoint extends AbstractEndpoint
         $config = $this->client->getConfig();
 
         return $this->makeRequest('POST', '/api/v3/crypto/deposit-history')
-            ->withQuery(array_filter($params, fn ($value) => $value !== null && $value !== ''))
+            ->withQuery($this->filterParams($params))
             ->acceptJson()
             ->withInterceptor(new GenerateSignatureV3($config, $this->client))
             ->send();
@@ -218,7 +218,7 @@ class CryptoEndpoint extends AbstractEndpoint
         $config = $this->client->getConfig();
 
         return $this->makeRequest('POST', '/api/v3/crypto/withdrawal-history')
-            ->withQuery(array_filter($params, fn ($value) => $value !== null && $value !== ''))
+            ->withQuery($this->filterParams($params))
             ->acceptJson()
             ->withInterceptor(new GenerateSignatureV3($config, $this->client))
             ->send();

--- a/src/Endpoints/MarketEndpoint.php
+++ b/src/Endpoints/MarketEndpoint.php
@@ -70,9 +70,9 @@ class MarketEndpoint extends AbstractEndpoint
     public function ticker(?string $symbol = null): ResponseInterface
     {
         return $this->makeRequest('GET', '/api/market/ticker')
-            ->withQuery(array_filter([
+            ->withQuery($this->filterParams([
                 'sym' => $symbol,
-            ], fn ($value) => $value !== null && $value !== ''))
+            ]))
             ->send();
     }
 
@@ -100,7 +100,7 @@ class MarketEndpoint extends AbstractEndpoint
     public function trades(array $params): ResponseInterface
     {
         return $this->makeRequest('GET', '/api/market/trades')
-            ->withQuery(array_filter($params, fn ($value) => $value !== null && $value !== ''))
+            ->withQuery($this->filterParams($params))
             ->send();
     }
 
@@ -132,7 +132,7 @@ class MarketEndpoint extends AbstractEndpoint
     public function bids(array $params): ResponseInterface
     {
         return $this->makeRequest('GET', '/api/market/bids')
-            ->withQuery(array_filter($params, fn ($value) => $value !== null && $value !== ''))
+            ->withQuery($this->filterParams($params))
             ->send();
     }
 
@@ -164,7 +164,7 @@ class MarketEndpoint extends AbstractEndpoint
     public function asks(array $params): ResponseInterface
     {
         return $this->makeRequest('GET', '/api/market/asks')
-            ->withQuery(array_filter($params, fn ($value) => $value !== null && $value !== ''))
+            ->withQuery($this->filterParams($params))
             ->send();
     }
 
@@ -207,7 +207,7 @@ class MarketEndpoint extends AbstractEndpoint
     public function books(array $params): ResponseInterface
     {
         return $this->makeRequest('GET', '/api/market/books')
-            ->withQuery(array_filter($params, fn ($value) => $value !== null && $value !== ''))
+            ->withQuery($this->filterParams($params))
             ->send();
     }
 
@@ -471,7 +471,7 @@ class MarketEndpoint extends AbstractEndpoint
         $config = $this->client->getConfig();
 
         return $this->makeRequest('GET', '/api/v3/market/my-order-history')
-            ->withQuery(array_filter($params, fn ($value) => $value !== null && $value !== ''))
+            ->withQuery($this->filterParams($params))
             ->acceptJson()
             ->withInterceptor(new GenerateSignatureV3($config, $this->client))
             ->send();
@@ -529,7 +529,7 @@ class MarketEndpoint extends AbstractEndpoint
         $config = $this->client->getConfig();
 
         return $this->makeRequest('GET', '/api/v3/market/order-info')
-            ->withQuery(array_filter($params, fn ($value) => $value !== null && $value !== ''))
+            ->withQuery($this->filterParams($params))
             ->acceptJson()
             ->withInterceptor(new GenerateSignatureV3($config, $this->client))
             ->send();

--- a/src/Endpoints/MarketEndpoint.php
+++ b/src/Endpoints/MarketEndpoint.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Farzai\Bitkub\Endpoints;
 
 use Farzai\Bitkub\Requests\GenerateSignatureV3;
@@ -70,7 +72,7 @@ class MarketEndpoint extends AbstractEndpoint
         return $this->makeRequest('GET', '/api/market/ticker')
             ->withQuery(array_filter([
                 'sym' => $symbol,
-            ]))
+            ], fn ($value) => $value !== null && $value !== ''))
             ->send();
     }
 
@@ -98,7 +100,7 @@ class MarketEndpoint extends AbstractEndpoint
     public function trades(array $params): ResponseInterface
     {
         return $this->makeRequest('GET', '/api/market/trades')
-            ->withQuery(array_filter($params))
+            ->withQuery(array_filter($params, fn ($value) => $value !== null && $value !== ''))
             ->send();
     }
 
@@ -130,7 +132,7 @@ class MarketEndpoint extends AbstractEndpoint
     public function bids(array $params): ResponseInterface
     {
         return $this->makeRequest('GET', '/api/market/bids')
-            ->withQuery(array_filter($params))
+            ->withQuery(array_filter($params, fn ($value) => $value !== null && $value !== ''))
             ->send();
     }
 
@@ -162,7 +164,7 @@ class MarketEndpoint extends AbstractEndpoint
     public function asks(array $params): ResponseInterface
     {
         return $this->makeRequest('GET', '/api/market/asks')
-            ->withQuery(array_filter($params))
+            ->withQuery(array_filter($params, fn ($value) => $value !== null && $value !== ''))
             ->send();
     }
 
@@ -205,7 +207,7 @@ class MarketEndpoint extends AbstractEndpoint
     public function books(array $params): ResponseInterface
     {
         return $this->makeRequest('GET', '/api/market/books')
-            ->withQuery(array_filter($params))
+            ->withQuery(array_filter($params, fn ($value) => $value !== null && $value !== ''))
             ->send();
     }
 
@@ -418,11 +420,9 @@ class MarketEndpoint extends AbstractEndpoint
         $config = $this->client->getConfig();
 
         return $this->makeRequest('GET', '/api/v3/market/my-open-orders')
+            ->withQuery(['sym' => $sym])
             ->acceptJson()
             ->withInterceptor(new GenerateSignatureV3($config, $this->client))
-            ->withBody([
-                'sym' => $sym,
-            ])
             ->send();
     }
 
@@ -471,7 +471,7 @@ class MarketEndpoint extends AbstractEndpoint
         $config = $this->client->getConfig();
 
         return $this->makeRequest('GET', '/api/v3/market/my-order-history')
-            ->withQuery(array_filter($params))
+            ->withQuery(array_filter($params, fn ($value) => $value !== null && $value !== ''))
             ->acceptJson()
             ->withInterceptor(new GenerateSignatureV3($config, $this->client))
             ->send();
@@ -529,7 +529,7 @@ class MarketEndpoint extends AbstractEndpoint
         $config = $this->client->getConfig();
 
         return $this->makeRequest('GET', '/api/v3/market/order-info')
-            ->withQuery(array_filter($params))
+            ->withQuery(array_filter($params, fn ($value) => $value !== null && $value !== ''))
             ->acceptJson()
             ->withInterceptor(new GenerateSignatureV3($config, $this->client))
             ->send();

--- a/src/Endpoints/SystemEndpoint.php
+++ b/src/Endpoints/SystemEndpoint.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Farzai\Bitkub\Endpoints;
 
 use Farzai\Transport\Contracts\ResponseInterface;

--- a/src/Endpoints/UserEndpoint.php
+++ b/src/Endpoints/UserEndpoint.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Farzai\Bitkub\Endpoints;
 
 use Farzai\Bitkub\Requests\GenerateSignatureV3;

--- a/src/Exceptions/BitkubResponseErrorCodeException.php
+++ b/src/Exceptions/BitkubResponseErrorCodeException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Farzai\Bitkub\Exceptions;
 
 use Farzai\Bitkub\Constants\ErrorCodes;
@@ -29,7 +31,9 @@ class BitkubResponseErrorCodeException extends \Exception
         }
 
         if (is_null($errorCode)) {
-            throw new \Exception('Error code not found.');
+            parent::__construct('Malformed response: error code not found.', 0);
+
+            return;
         }
 
         $message = ErrorCodes::getDescription($errorCode);

--- a/src/Exceptions/InvalidArgumentException.php
+++ b/src/Exceptions/InvalidArgumentException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Farzai\Bitkub\Exceptions;
 
 use InvalidArgumentException as BaseInvalidArgumentException;

--- a/src/Requests/GenerateSignatureV3.php
+++ b/src/Requests/GenerateSignatureV3.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Farzai\Bitkub\Requests;
 
 use Farzai\Bitkub\Contracts\ClientInterface;
@@ -22,6 +24,12 @@ class GenerateSignatureV3 implements RequestInterceptor
      */
     private ClientInterface $client;
 
+    private static ?int $serverTimeDriftMs = null;
+
+    private static float $lastSyncTime = 0;
+
+    private const SYNC_INTERVAL_SECONDS = 300;
+
     /**
      * Create a new client instance.
      */
@@ -36,13 +44,14 @@ class GenerateSignatureV3 implements RequestInterceptor
      */
     public function apply(PsrRequestInterface $request): PsrRequestInterface
     {
-        $endpoint = new SystemEndpoint($this->client);
-
-        $timestamp = (int) $endpoint->serverTimestamp()->throw()->body();
+        $timestamp = $this->getTimestamp();
 
         $method = strtoupper($request->getMethod());
         $path = '/'.trim($request->getUri()->getPath(), '/');
-        $payload = $request->getBody()->getContents() ?: '';
+
+        $body = $request->getBody();
+        $payload = $body->getContents() ?: '';
+        $body->rewind();
 
         $query = $request->getUri()->getQuery();
         if (! empty($query)) {
@@ -53,6 +62,29 @@ class GenerateSignatureV3 implements RequestInterceptor
 
         return $request->withHeader('X-BTK-APIKEY', $this->config['api_key'])
             ->withHeader('X-BTK-SIGN', $signature)
-            ->withHeader('X-BTK-TIMESTAMP', $timestamp);
+            ->withHeader('X-BTK-TIMESTAMP', (string) $timestamp);
+    }
+
+    private function getTimestamp(): int
+    {
+        $now = (int) (microtime(true) * 1000);
+
+        if (self::$serverTimeDriftMs === null || (microtime(true) - self::$lastSyncTime) > self::SYNC_INTERVAL_SECONDS) {
+            $endpoint = new SystemEndpoint($this->client);
+            $serverTime = (int) $endpoint->serverTimestamp()->throw()->body();
+            self::$serverTimeDriftMs = $serverTime - $now;
+            self::$lastSyncTime = microtime(true);
+        }
+
+        return $now + self::$serverTimeDriftMs;
+    }
+
+    /**
+     * Reset the cached timestamp drift (useful for testing).
+     */
+    public static function resetTimestampCache(): void
+    {
+        self::$serverTimeDriftMs = null;
+        self::$lastSyncTime = 0;
     }
 }

--- a/src/Requests/GenerateSignatureV3.php
+++ b/src/Requests/GenerateSignatureV3.php
@@ -24,9 +24,9 @@ class GenerateSignatureV3 implements RequestInterceptor
      */
     private ClientInterface $client;
 
-    private static ?int $serverTimeDriftMs = null;
+    private ?int $serverTimeDriftMs = null;
 
-    private static float $lastSyncTime = 0;
+    private float $lastSyncTime = 0;
 
     private const SYNC_INTERVAL_SECONDS = 300;
 
@@ -69,22 +69,13 @@ class GenerateSignatureV3 implements RequestInterceptor
     {
         $now = (int) (microtime(true) * 1000);
 
-        if (self::$serverTimeDriftMs === null || (microtime(true) - self::$lastSyncTime) > self::SYNC_INTERVAL_SECONDS) {
+        if ($this->serverTimeDriftMs === null || (microtime(true) - $this->lastSyncTime) > self::SYNC_INTERVAL_SECONDS) {
             $endpoint = new SystemEndpoint($this->client);
             $serverTime = (int) $endpoint->serverTimestamp()->throw()->body();
-            self::$serverTimeDriftMs = $serverTime - $now;
-            self::$lastSyncTime = microtime(true);
+            $this->serverTimeDriftMs = $serverTime - $now;
+            $this->lastSyncTime = microtime(true);
         }
 
-        return $now + self::$serverTimeDriftMs;
-    }
-
-    /**
-     * Reset the cached timestamp drift (useful for testing).
-     */
-    public static function resetTimestampCache(): void
-    {
-        self::$serverTimeDriftMs = null;
-        self::$lastSyncTime = 0;
+        return $now + $this->serverTimeDriftMs;
     }
 }

--- a/src/Requests/PendingRequest.php
+++ b/src/Requests/PendingRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Farzai\Bitkub\Requests;
 
 use Farzai\Bitkub\Contracts\ClientInterface;
@@ -13,20 +15,20 @@ use Psr\Http\Message\ResponseInterface as PsrResponseInterface;
 
 class PendingRequest
 {
-    public ClientInterface $client;
+    private ClientInterface $client;
 
-    public string $method;
+    private string $method;
 
-    public string $path;
+    private string $path;
 
-    public array $options;
+    private array $options;
 
     /**
      * The request interceptors.
      *
-     * @var array<\Farzai\Bitkub\Contracts\RequestInterceptor>
+     * @var array<RequestInterceptor>
      */
-    public $interceptors = [];
+    private array $interceptors = [];
 
     /**
      * Create a new pending request instance.
@@ -42,7 +44,7 @@ class PendingRequest
     /**
      * Set the request method.
      */
-    public function method(string $method)
+    public function method(string $method): static
     {
         $this->method = $method;
 
@@ -52,7 +54,7 @@ class PendingRequest
     /**
      * Set the request path.
      */
-    public function path(string $path)
+    public function path(string $path): static
     {
         $this->path = $path;
 
@@ -62,14 +64,14 @@ class PendingRequest
     /**
      * Set the request options.
      */
-    public function options(array $options)
+    public function options(array $options): static
     {
         $this->options = $options;
 
         return $this;
     }
 
-    public function withInterceptor(RequestInterceptor $interceptor)
+    public function withInterceptor(RequestInterceptor $interceptor): static
     {
         $this->interceptors[] = $interceptor;
 
@@ -79,7 +81,7 @@ class PendingRequest
     /**
      * Set the request body.
      */
-    public function withBody(mixed $body)
+    public function withBody(mixed $body): static
     {
         $this->options['body'] = $body;
 
@@ -89,7 +91,7 @@ class PendingRequest
     /**
      * Set the request query.
      */
-    public function withQuery(array $query)
+    public function withQuery(array $query): static
     {
         $this->options['query'] = $query;
 
@@ -99,26 +101,26 @@ class PendingRequest
     /**
      * Set the request headers.
      */
-    public function withHeaders(array $headers)
+    public function withHeaders(array $headers): static
     {
         $this->options['headers'] = array_merge($this->options['headers'] ?? [], $headers);
 
         return $this;
     }
 
-    public function withHeader(string $key, string $value)
+    public function withHeader(string $key, string $value): static
     {
         $this->options['headers'][$key] = $value;
 
         return $this;
     }
 
-    public function acceptJson()
+    public function acceptJson(): static
     {
         return $this->withHeader('Accept', 'application/json');
     }
 
-    public function asJson()
+    public function asJson(): static
     {
         return $this->withHeader('Content-Type', 'application/json');
     }

--- a/src/Responses/AbstractResponseDecorator.php
+++ b/src/Responses/AbstractResponseDecorator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Farzai\Bitkub\Responses;
 
 use Farzai\Transport\Contracts\ResponseInterface;

--- a/src/Responses/ResponseWithValidateErrorCode.php
+++ b/src/Responses/ResponseWithValidateErrorCode.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Farzai\Bitkub\Responses;
 
 use Farzai\Bitkub\Exceptions\BitkubResponseErrorCodeException;
@@ -15,13 +17,17 @@ class ResponseWithValidateErrorCode extends AbstractResponseDecorator
      */
     public function throw(?callable $callback = null): static
     {
-        parent::throw($callback ?? function (ResponseInterface $response, ?\Exception $e) use ($callback) {
+        parent::throw(function (ResponseInterface $response, ?\Exception $e) use ($callback) {
             $errorCode = $this->json('error');
             if ($errorCode !== null && $errorCode !== 0) {
                 throw new BitkubResponseErrorCodeException($response);
             }
 
-            return $callback ? $callback($response, $e) : $response;
+            if ($callback) {
+                return $callback($response, $e);
+            }
+
+            return $response;
         });
 
         return $this;

--- a/src/UriFactory.php
+++ b/src/UriFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Farzai\Bitkub;
 
 use Phrity\Net\Uri;

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Farzai\Bitkub;
 
 class Utility
@@ -7,11 +9,16 @@ class Utility
     /**
      * Generate signature.
      */
-    public static function generateSignature($secret, $timestamp, $method, $path, $query, $payload)
-    {
+    public static function generateSignature(
+        string $secret,
+        int $timestamp,
+        string $method,
+        string $path,
+        string $query,
+        string $payload
+    ): string {
         $message = sprintf('%s%s%s%s%s', $timestamp, $method, $path, $query, $payload);
-        $signature = hash_hmac('sha256', $message, $secret);
 
-        return $signature;
+        return hash_hmac('sha256', $message, $secret);
     }
 }

--- a/src/WebSocket/Endpoints/AbstractEndpoint.php
+++ b/src/WebSocket/Endpoints/AbstractEndpoint.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Farzai\Bitkub\WebSocket\Endpoints;
 
 use Farzai\Bitkub\WebSocketClient;
@@ -16,12 +18,12 @@ abstract class AbstractEndpoint
     /**
      * Run the websocket.
      */
-    public function run()
+    public function run(): void
     {
         $this->websocket->run();
     }
 
-    protected function getLogger()
+    protected function getLogger(): \Psr\Log\LoggerInterface
     {
         return $this->websocket->getLogger();
     }

--- a/src/WebSocket/Endpoints/LiveOrderBookEndpoint.php
+++ b/src/WebSocket/Endpoints/LiveOrderBookEndpoint.php
@@ -1,11 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Farzai\Bitkub\WebSocket\Endpoints;
 
 use Farzai\Bitkub\Endpoints as RestApiEndpoints;
 
 class LiveOrderBookEndpoint extends AbstractEndpoint
 {
+    /** @var array<string, int>|null */
+    private static ?array $symbolMap = null;
+
     /**
      * Add event listener.
      *
@@ -18,32 +23,39 @@ class LiveOrderBookEndpoint extends AbstractEndpoint
      */
     public function listen($symbol, $listeners)
     {
-        // Check if symbol is numeric.
         if (! is_numeric($symbol)) {
-
-            $this->getLogger()->debug('Find symbol id by name: '.$symbol);
-
-            // Find symbol id by name.
-            $market = new RestApiEndpoints\MarketEndpoint($this->websocket->getClient());
-
-            foreach ($market->symbols()->throw()->json('result') as $item) {
-                if ($item['symbol'] === strtoupper(trim($symbol))) {
-                    $symbol = $item['id'];
-
-                    $this->getLogger()->debug('Found symbol id: '.$symbol);
-                    break;
-                }
-            }
-
-            if (! is_numeric($symbol)) {
-                $this->getLogger()->debug('Invalid symbol name. Given: '.$symbol);
-
-                throw new \InvalidArgumentException('Invalid symbol name. Given: '.$symbol);
-            }
+            $symbol = $this->resolveSymbolId((string) $symbol);
         }
 
         $this->websocket->addListener('orderbook/'.$symbol, $listeners);
 
         return $this;
+    }
+
+    private function resolveSymbolId(string $symbol): int
+    {
+        if (self::$symbolMap === null) {
+            self::$symbolMap = [];
+            $market = new RestApiEndpoints\MarketEndpoint($this->websocket->getClient());
+
+            foreach ($market->symbols()->throw()->json('result') as $item) {
+                self::$symbolMap[strtoupper($item['symbol'])] = $item['id'];
+            }
+        }
+
+        $key = strtoupper(trim($symbol));
+        if (! isset(self::$symbolMap[$key])) {
+            throw new \InvalidArgumentException('Invalid symbol name. Given: '.$symbol);
+        }
+
+        return self::$symbolMap[$key];
+    }
+
+    /**
+     * Reset the cached symbol map (useful for testing).
+     */
+    public static function resetSymbolMapCache(): void
+    {
+        self::$symbolMap = null;
     }
 }

--- a/src/WebSocket/Endpoints/LiveOrderBookEndpoint.php
+++ b/src/WebSocket/Endpoints/LiveOrderBookEndpoint.php
@@ -9,7 +9,7 @@ use Farzai\Bitkub\Endpoints as RestApiEndpoints;
 class LiveOrderBookEndpoint extends AbstractEndpoint
 {
     /** @var array<string, int>|null */
-    private static ?array $symbolMap = null;
+    private ?array $symbolMap = null;
 
     /**
      * Add event listener.
@@ -19,9 +19,9 @@ class LiveOrderBookEndpoint extends AbstractEndpoint
      * });
      *
      * @param  string|int  $symbol  Symbol name or id.
-     * @param  callable|array<callable>  $listeners
+     * @param  callable|array<callable(\Farzai\Bitkub\WebSocket\Message): void>  $listeners
      */
-    public function listen($symbol, $listeners)
+    public function listen(string|int $symbol, callable|array $listeners): static
     {
         if (! is_numeric($symbol)) {
             $symbol = $this->resolveSymbolId((string) $symbol);
@@ -34,28 +34,25 @@ class LiveOrderBookEndpoint extends AbstractEndpoint
 
     private function resolveSymbolId(string $symbol): int
     {
-        if (self::$symbolMap === null) {
-            self::$symbolMap = [];
-            $market = new RestApiEndpoints\MarketEndpoint($this->websocket->getClient());
+        $client = $this->websocket->getClient();
+        if ($client === null) {
+            throw new \RuntimeException('A REST client is required to resolve symbol names. Use numeric symbol IDs or set a client via WebSocketClientBuilder::setClient().');
+        }
+
+        if ($this->symbolMap === null) {
+            $this->symbolMap = [];
+            $market = new RestApiEndpoints\MarketEndpoint($client);
 
             foreach ($market->symbols()->throw()->json('result') as $item) {
-                self::$symbolMap[strtoupper($item['symbol'])] = $item['id'];
+                $this->symbolMap[strtoupper($item['symbol'])] = $item['id'];
             }
         }
 
         $key = strtoupper(trim($symbol));
-        if (! isset(self::$symbolMap[$key])) {
+        if (! isset($this->symbolMap[$key])) {
             throw new \InvalidArgumentException('Invalid symbol name. Given: '.$symbol);
         }
 
-        return self::$symbolMap[$key];
-    }
-
-    /**
-     * Reset the cached symbol map (useful for testing).
-     */
-    public static function resetSymbolMapCache(): void
-    {
-        self::$symbolMap = null;
+        return $this->symbolMap[$key];
     }
 }

--- a/src/WebSocket/Endpoints/MarketEndpoint.php
+++ b/src/WebSocket/Endpoints/MarketEndpoint.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Farzai\Bitkub\WebSocket\Endpoints;
 
 class MarketEndpoint extends AbstractEndpoint
@@ -51,8 +53,7 @@ class MarketEndpoint extends AbstractEndpoint
     {
         $streamName = 'market.'.preg_replace('/^market\./', '', $streamName);
 
-        // Validate stream name format.
-        if (substr_count($streamName, '.') === 2) {
+        if (preg_match('/^market\.[a-z]+\.[a-z0-9_]+$/i', $streamName)) {
             return $streamName;
         }
 

--- a/src/WebSocket/Endpoints/MarketEndpoint.php
+++ b/src/WebSocket/Endpoints/MarketEndpoint.php
@@ -14,13 +14,13 @@ class MarketEndpoint extends AbstractEndpoint
      * });
      *
      * @param  string[]|string  $streamNames
-     * @param  callable|array<callable>  $listeners
+     * @param  callable|array<callable(\Farzai\Bitkub\WebSocket\Message): void>  $listeners
      */
-    public function listen($streamNames, $listeners)
+    public function listen(string|array $streamNames, callable|array $listeners): static
     {
         $streamNames = $this->normalizeStreamNames($streamNames);
 
-        $this->getLogger()->debug('Add event listener for stream: '.implode(', ', $streamNames));
+        $this->getLogger()->debug('Subscribing to streams: '.implode(', ', $streamNames));
 
         foreach ($streamNames as $name) {
             $this->websocket->addListener($name, $listeners);
@@ -33,18 +33,23 @@ class MarketEndpoint extends AbstractEndpoint
      * Normalize stream names.
      *
      * @param  string[]|string  $streamNames
+     * @return string[]
      */
-    private function normalizeStreamNames($streamNames): array
+    private function normalizeStreamNames(string|array $streamNames): array
     {
         if (is_string($streamNames)) {
             $streamNames = explode(',', $streamNames);
         }
 
-        $streamNames = array_filter(array_map('trim', $streamNames), function ($streamName) {
-            return ! empty($streamName);
-        });
+        $streamNames = array_filter(
+            array_map('trim', $streamNames),
+            fn (string $name): bool => ! empty($name),
+        );
 
-        $streamNames = array_map(fn ($streamName) => $this->getStreamName($streamName), $streamNames);
+        $streamNames = array_map(
+            fn (string $name): string => $this->getStreamName($name),
+            $streamNames,
+        );
 
         return $streamNames;
     }

--- a/src/WebSocket/Engine.php
+++ b/src/WebSocket/Engine.php
@@ -16,56 +16,74 @@ class Engine implements WebSocketEngineInterface
 {
     public function __construct(
         private LoggerInterface $logger,
+        private string $baseUrl = 'wss://api.bitkub.com/websocket-api/',
+        private int $reconnectAttempts = 3,
+        private int $reconnectDelayMs = 1000,
     ) {}
 
     public function handle(array $listeners): void
     {
         $events = $this->getEventNames($listeners);
+        $url = rtrim($this->baseUrl, '/').'/'.implode(',', $events);
 
-        $this->logger->info('[WebSocket] - Connecting to WebSocket server...');
+        $attempt = 0;
 
-        $this->logger->debug('[WebSocket] - Events: '.implode(', ', $events));
-
-        $client = new WebSocketClient('wss://api.bitkub.com/websocket-api/'.implode(',', $events));
-
-        $client
-            ->addMiddleware(new WebSocketMiddleware\CloseHandler)
-            ->addMiddleware(new WebSocketMiddleware\PingResponder);
-
-        $client->onText(function (WebSocketClient $client, WebSocketConnection $connection, WebSocketMessage $message) use ($listeners) {
-            $receivedAt = Carbon::now();
-
-            $data = json_decode($message->getContent(), true);
-            if (! is_array($data) || ! isset($data['stream'])) {
-                $this->logger->warning('[WebSocket] - Received non-JSON or unknown message format.');
-
-                return;
+        do {
+            if ($attempt > 0) {
+                $this->logger->info('[WebSocket] - Reconnecting (attempt '.$attempt.' of '.$this->reconnectAttempts.')...');
+                usleep($this->reconnectDelayMs * 1000);
             }
 
-            $event = $data['stream'];
-            if (! isset($listeners[$event])) {
-                $this->logger->warning('[WebSocket] - Unknown event: '.$event);
+            $this->logger->info('[WebSocket] - Connecting to WebSocket server...');
+            $this->logger->debug('[WebSocket] - Events: '.implode(', ', $events));
 
-                return;
-            }
+            $client = new WebSocketClient($url);
 
-            $message = new Message(
-                $message->getContent(),
-                $receivedAt->toDateTimeImmutable(),
-            );
+            $client
+                ->addMiddleware(new WebSocketMiddleware\CloseHandler)
+                ->addMiddleware(new WebSocketMiddleware\PingResponder);
 
-            foreach ($listeners[$event] as $listener) {
-                $this->logger->info('[WebSocket] - Event: '.$event);
+            $client->onText(function (WebSocketClient $client, WebSocketConnection $connection, WebSocketMessage $message) use ($listeners) {
+                $receivedAt = Carbon::now();
 
-                $listener($message);
-            }
-        });
+                $data = json_decode($message->getContent(), true);
+                if (! is_array($data) || ! isset($data['stream'])) {
+                    $this->logger->warning('[WebSocket] - Received non-JSON or unknown message format.');
 
-        $client->onClose(function () {
-            $this->logger->info('[WebSocket] - Connection closed.');
-        });
+                    return;
+                }
 
-        $client->start();
+                $event = $data['stream'];
+                if (! isset($listeners[$event])) {
+                    $this->logger->warning('[WebSocket] - Unknown event: '.$event);
+
+                    return;
+                }
+
+                $wsMessage = new Message(
+                    $message->getContent(),
+                    $receivedAt->toDateTimeImmutable(),
+                    $data,
+                );
+
+                foreach ($listeners[$event] as $listener) {
+                    $this->logger->debug('[WebSocket] - Event: '.$event);
+
+                    try {
+                        $listener($wsMessage);
+                    } catch (\Throwable $e) {
+                        $this->logger->error('[WebSocket] - Listener error on event '.$event.': '.$e->getMessage());
+                    }
+                }
+            });
+
+            $client->onClose(function () {
+                $this->logger->info('[WebSocket] - Connection closed.');
+            });
+
+            $client->start();
+            $attempt++;
+        } while ($attempt <= $this->reconnectAttempts);
     }
 
     private function getEventNames(array $listeners): array

--- a/src/WebSocket/Engine.php
+++ b/src/WebSocket/Engine.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Farzai\Bitkub\WebSocket;
 
 use Farzai\Bitkub\Contracts\WebSocketEngineInterface;
@@ -33,9 +35,9 @@ class Engine implements WebSocketEngineInterface
         $client->onText(function (WebSocketClient $client, WebSocketConnection $connection, WebSocketMessage $message) use ($listeners) {
             $receivedAt = Carbon::now();
 
-            $data = @json_decode($message->getContent(), true) ?? [];
-            if (! isset($data['stream'])) {
-                $this->logger->warning('[WebSocket] - Unknown data: '.$message->getContent());
+            $data = json_decode($message->getContent(), true);
+            if (! is_array($data) || ! isset($data['stream'])) {
+                $this->logger->warning('[WebSocket] - Received non-JSON or unknown message format.');
 
                 return;
             }

--- a/src/WebSocket/Engine.php
+++ b/src/WebSocket/Engine.php
@@ -81,7 +81,13 @@ class Engine implements WebSocketEngineInterface
                 $this->logger->info('[WebSocket] - Connection closed.');
             });
 
-            $client->start();
+            try {
+                $client->start();
+                break; // Clean close — no reconnect needed
+            } catch (\Throwable $e) {
+                $this->logger->error('[WebSocket] - Connection error: '.$e->getMessage());
+            }
+
             $attempt++;
         } while ($attempt <= $this->reconnectAttempts);
     }

--- a/src/WebSocket/Message.php
+++ b/src/WebSocket/Message.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Farzai\Bitkub\WebSocket;
 
 use ArrayAccess;
@@ -10,14 +12,15 @@ class Message implements \JsonSerializable, ArrayAccess
 {
     private string $body;
 
-    private $jsonDecoded;
+    private ?array $jsonDecoded;
 
     private DateTimeImmutable $receivedAt;
 
     public function __construct(string $body, DateTimeImmutable $receivedAt)
     {
         $this->body = $body;
-        $this->jsonDecoded = @json_decode($body, true) ?? false;
+        $decoded = json_decode($body, true);
+        $this->jsonDecoded = is_array($decoded) ? $decoded : null;
         $this->receivedAt = $receivedAt;
     }
 
@@ -34,7 +37,7 @@ class Message implements \JsonSerializable, ArrayAccess
     public function json($key = null)
     {
         if ($key === null) {
-            return $this->jsonDecoded ?: null;
+            return $this->jsonDecoded;
         }
 
         return Arr::get($this->jsonDecoded, $key);
@@ -52,7 +55,7 @@ class Message implements \JsonSerializable, ArrayAccess
 
     public function toArray(): array
     {
-        return $this->jsonDecoded;
+        return $this->jsonDecoded ?? [];
     }
 
     public function offsetExists($offset): bool
@@ -67,12 +70,12 @@ class Message implements \JsonSerializable, ArrayAccess
 
     public function offsetSet($offset, $value): void
     {
-        $this->jsonDecoded[$offset] = $value;
+        throw new \BadMethodCallException('Message is immutable.');
     }
 
     public function offsetUnset($offset): void
     {
-        unset($this->jsonDecoded[$offset]);
+        throw new \BadMethodCallException('Message is immutable.');
     }
 
     public function __get($name)
@@ -87,11 +90,11 @@ class Message implements \JsonSerializable, ArrayAccess
 
     public function __set($name, $value): void
     {
-        $this->jsonDecoded[$name] = $value;
+        throw new \BadMethodCallException('Message is immutable.');
     }
 
     public function __unset($name): void
     {
-        unset($this->jsonDecoded[$name]);
+        throw new \BadMethodCallException('Message is immutable.');
     }
 }

--- a/src/WebSocket/Message.php
+++ b/src/WebSocket/Message.php
@@ -44,6 +44,10 @@ class Message implements \JsonSerializable, ArrayAccess
             return $this->jsonDecoded;
         }
 
+        if ($this->jsonDecoded === null) {
+            return null;
+        }
+
         return Arr::get($this->jsonDecoded, $key);
     }
 

--- a/src/WebSocket/Message.php
+++ b/src/WebSocket/Message.php
@@ -16,11 +16,15 @@ class Message implements \JsonSerializable, ArrayAccess
 
     private DateTimeImmutable $receivedAt;
 
-    public function __construct(string $body, DateTimeImmutable $receivedAt)
+    public function __construct(string $body, DateTimeImmutable $receivedAt, ?array $decoded = null)
     {
         $this->body = $body;
-        $decoded = json_decode($body, true);
-        $this->jsonDecoded = is_array($decoded) ? $decoded : null;
+        if ($decoded !== null) {
+            $this->jsonDecoded = $decoded;
+        } else {
+            $raw = json_decode($body, true);
+            $this->jsonDecoded = is_array($raw) ? $raw : null;
+        }
         $this->receivedAt = $receivedAt;
     }
 

--- a/src/WebSocketClient.php
+++ b/src/WebSocketClient.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Farzai\Bitkub;
 
 use Farzai\Bitkub\Contracts\ClientInterface;
@@ -62,7 +64,7 @@ class WebSocketClient
         return $this->listeners;
     }
 
-    public function run()
+    public function run(): void
     {
         $this->websocket->handle($this->listeners);
     }

--- a/src/WebSocketClient.php
+++ b/src/WebSocketClient.php
@@ -7,48 +7,56 @@ namespace Farzai\Bitkub;
 use Farzai\Bitkub\Contracts\ClientInterface;
 use Farzai\Bitkub\Contracts\WebSocketEngineInterface;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 class WebSocketClient
 {
-    private ClientInterface $client;
-
-    private Contracts\WebSocketEngineInterface $websocket;
-
     /**
-     * @var array<string, array<mixed>>
+     * @var array<string, array<callable(\Farzai\Bitkub\WebSocket\Message): void>>
      */
     private array $listeners = [];
 
+    private ?WebSocket\Endpoints\MarketEndpoint $marketEndpoint = null;
+
+    private ?WebSocket\Endpoints\LiveOrderBookEndpoint $liveOrderBookEndpoint = null;
+
     public function __construct(
-        ClientInterface $client,
-        ?WebSocketEngineInterface $websocket = null
-    ) {
-        $this->client = $client;
-        $this->websocket = $websocket ?: new WebSocket\Engine($this->getLogger());
-    }
+        private WebSocketEngineInterface $engine,
+        private ?ClientInterface $client = null,
+        private ?LoggerInterface $logger = null,
+    ) {}
 
     public function getConfig(): array
     {
-        return $this->client->getConfig();
+        return $this->client?->getConfig() ?? [];
     }
 
     public function getLogger(): LoggerInterface
     {
-        return $this->client->getLogger();
+        return $this->logger ?? $this->client?->getLogger() ?? new NullLogger;
     }
 
-    public function getClient(): ClientInterface
+    public function getClient(): ?ClientInterface
     {
         return $this->client;
+    }
+
+    public function market(): WebSocket\Endpoints\MarketEndpoint
+    {
+        return $this->marketEndpoint ??= new WebSocket\Endpoints\MarketEndpoint($this);
+    }
+
+    public function liveOrderBook(): WebSocket\Endpoints\LiveOrderBookEndpoint
+    {
+        return $this->liveOrderBookEndpoint ??= new WebSocket\Endpoints\LiveOrderBookEndpoint($this);
     }
 
     /**
      * Add event listener.
      *
-     * @param  callable|array<callable>  $listener
-     * @return $this
+     * @param  callable|array<callable(\Farzai\Bitkub\WebSocket\Message): void>  $listener
      */
-    public function addListener(string $event, $listener)
+    public function addListener(string $event, callable|array $listener): static
     {
         if (! isset($this->listeners[$event])) {
             $this->listeners[$event] = [];
@@ -59,6 +67,9 @@ class WebSocketClient
         return $this;
     }
 
+    /**
+     * @return array<string, array<callable(\Farzai\Bitkub\WebSocket\Message): void>>
+     */
     public function getListeners(): array
     {
         return $this->listeners;
@@ -66,6 +77,6 @@ class WebSocketClient
 
     public function run(): void
     {
-        $this->websocket->handle($this->listeners);
+        $this->engine->handle($this->listeners);
     }
 }

--- a/src/WebSocketClientBuilder.php
+++ b/src/WebSocketClientBuilder.php
@@ -25,7 +25,7 @@ final class WebSocketClientBuilder
 
     private int $reconnectDelayMs = 1000;
 
-    final public function __construct() {}
+    public function __construct() {}
 
     public static function create(): static
     {

--- a/src/WebSocketClientBuilder.php
+++ b/src/WebSocketClientBuilder.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Farzai\Bitkub;
+
+use Farzai\Bitkub\Contracts\ClientInterface;
+use Farzai\Bitkub\Contracts\WebSocketEngineInterface;
+use Psr\Log\LoggerInterface as PsrLoggerInterface;
+use Psr\Log\NullLogger;
+
+final class WebSocketClientBuilder
+{
+    private const DEFAULT_WS_BASE_URL = 'wss://api.bitkub.com/websocket-api/';
+
+    private ?ClientInterface $client = null;
+
+    private ?WebSocketEngineInterface $engine = null;
+
+    private ?PsrLoggerInterface $logger = null;
+
+    private string $baseUrl = self::DEFAULT_WS_BASE_URL;
+
+    private int $reconnectAttempts = 3;
+
+    private int $reconnectDelayMs = 1000;
+
+    final public function __construct() {}
+
+    public static function create(): static
+    {
+        return new self;
+    }
+
+    public function setClient(ClientInterface $client): static
+    {
+        $this->client = $client;
+
+        return $this;
+    }
+
+    public function setEngine(WebSocketEngineInterface $engine): static
+    {
+        $this->engine = $engine;
+
+        return $this;
+    }
+
+    public function setLogger(PsrLoggerInterface $logger): static
+    {
+        $this->logger = $logger;
+
+        return $this;
+    }
+
+    public function setBaseUrl(string $baseUrl): static
+    {
+        $this->baseUrl = $baseUrl;
+
+        return $this;
+    }
+
+    public function setReconnectAttempts(int $reconnectAttempts): static
+    {
+        if ($reconnectAttempts < 0) {
+            throw new \InvalidArgumentException('Reconnect attempts must be greater than or equal to 0.');
+        }
+
+        $this->reconnectAttempts = $reconnectAttempts;
+
+        return $this;
+    }
+
+    public function setReconnectDelayMs(int $reconnectDelayMs): static
+    {
+        if ($reconnectDelayMs < 0) {
+            throw new \InvalidArgumentException('Reconnect delay must be greater than or equal to 0.');
+        }
+
+        $this->reconnectDelayMs = $reconnectDelayMs;
+
+        return $this;
+    }
+
+    public function build(): WebSocketClient
+    {
+        $logger = $this->logger ?? $this->client?->getLogger() ?? new NullLogger;
+
+        $engine = $this->engine ?? new WebSocket\Engine(
+            logger: $logger,
+            baseUrl: $this->baseUrl,
+            reconnectAttempts: $this->reconnectAttempts,
+            reconnectDelayMs: $this->reconnectDelayMs,
+        );
+
+        return new WebSocketClient(
+            engine: $engine,
+            client: $this->client,
+            logger: $logger,
+        );
+    }
+}

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 it('will not use debugging functions')
     ->expect(['dd', 'dump', 'ray'])
     ->not->toBeUsed();

--- a/tests/AuthorizerTest.php
+++ b/tests/AuthorizerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Farzai\Bitkub\ClientBuilder;
 use Farzai\Bitkub\Endpoints\SystemEndpoint;
 use Farzai\Bitkub\Tests\MockHttpClient;

--- a/tests/AuthorizerTest.php
+++ b/tests/AuthorizerTest.php
@@ -33,3 +33,53 @@ it('can generate signature success', function () {
 
     expect($signature)->toBe('ae6fd3dc7d85ebea023e54292fa6eebaeea6dc02002433c51b57136eeb0a03e5');
 });
+
+it('generates different signatures with non-empty query', function () {
+    $secret = 'secret';
+    $timestamp = 1630483200000;
+    $method = 'GET';
+    $path = '/api/market/trades';
+
+    $sigWithoutQuery = Utility::generateSignature($secret, $timestamp, $method, $path, '', '');
+    $sigWithQuery = Utility::generateSignature($secret, $timestamp, $method, $path, '?sym=THB_BTC', '');
+
+    expect($sigWithoutQuery)->not->toBe($sigWithQuery);
+});
+
+it('generates different signatures with non-empty payload', function () {
+    $secret = 'secret';
+    $timestamp = 1630483200000;
+    $method = 'POST';
+    $path = '/api/v3/market/place-bid';
+
+    $sigWithoutPayload = Utility::generateSignature($secret, $timestamp, $method, $path, '', '');
+    $sigWithPayload = Utility::generateSignature($secret, $timestamp, $method, $path, '', '{"sym":"THB_BTC","amt":1000}');
+
+    expect($sigWithoutPayload)->not->toBe($sigWithPayload);
+});
+
+it('generates different signatures for different methods', function () {
+    $secret = 'secret';
+    $timestamp = 1630483200000;
+    $path = '/api/market/trades';
+
+    $sigGet = Utility::generateSignature($secret, $timestamp, 'GET', $path, '', '');
+    $sigPost = Utility::generateSignature($secret, $timestamp, 'POST', $path, '', '');
+
+    expect($sigGet)->not->toBe($sigPost);
+});
+
+it('generates consistent signatures for same inputs', function () {
+    $secret = 'secret';
+    $timestamp = 1630483200000;
+    $method = 'POST';
+    $path = '/api/v3/market/balances';
+    $query = '?sym=THB_BTC';
+    $payload = '{"amt":1000}';
+
+    $sig1 = Utility::generateSignature($secret, $timestamp, $method, $path, $query, $payload);
+    $sig2 = Utility::generateSignature($secret, $timestamp, $method, $path, $query, $payload);
+
+    expect($sig1)->toBe($sig2);
+    expect(strlen($sig1))->toBe(64); // SHA-256 hex
+});

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -64,3 +64,94 @@ it('should throw exception when retries is negative', function () {
     ClientBuilder::create()
         ->setRetries(-1);
 })->throws(\InvalidArgumentException::class, 'Retries must be greater than or equal to 0.');
+
+it('can set retries to zero', function () {
+    $client = ClientBuilder::create()
+        ->setCredentials('test', 'secret')
+        ->setRetries(0)
+        ->build();
+
+    expect($client)->toBeInstanceOf(Client::class);
+});
+
+it('returns same market endpoint instance (lazy singleton)', function () {
+    $client = ClientBuilder::create()
+        ->setCredentials('test', 'secret')
+        ->build();
+
+    $first = $client->market();
+    $second = $client->market();
+
+    expect($first)->toBe($second);
+});
+
+it('returns same crypto endpoint instance (lazy singleton)', function () {
+    $client = ClientBuilder::create()
+        ->setCredentials('test', 'secret')
+        ->build();
+
+    $first = $client->crypto();
+    $second = $client->crypto();
+
+    expect($first)->toBe($second);
+});
+
+it('returns same user endpoint instance (lazy singleton)', function () {
+    $client = ClientBuilder::create()
+        ->setCredentials('test', 'secret')
+        ->build();
+
+    $first = $client->user();
+    $second = $client->user();
+
+    expect($first)->toBe($second);
+});
+
+it('returns same system endpoint instance (lazy singleton)', function () {
+    $client = ClientBuilder::create()
+        ->setCredentials('test', 'secret')
+        ->build();
+
+    $first = $client->system();
+    $second = $client->system();
+
+    expect($first)->toBe($second);
+});
+
+it('can access getTransport', function () {
+    $client = ClientBuilder::create()
+        ->setCredentials('test', 'secret')
+        ->build();
+
+    expect($client->getTransport())->toBeInstanceOf(\Farzai\Transport\Transport::class);
+});
+
+it('can access getConfig with correct keys', function () {
+    $client = ClientBuilder::create()
+        ->setCredentials('my-api-key', 'my-secret')
+        ->build();
+
+    $config = $client->getConfig();
+
+    expect($config)->toHaveKey('api_key', 'my-api-key');
+    expect($config)->toHaveKey('secret', 'my-secret');
+});
+
+it('can access getLogger', function () {
+    $client = ClientBuilder::create()
+        ->setCredentials('test', 'secret')
+        ->build();
+
+    expect($client->getLogger())->toBeInstanceOf(\Psr\Log\LoggerInterface::class);
+});
+
+it('uses custom logger when set', function () {
+    $logger = new \Psr\Log\NullLogger;
+
+    $client = ClientBuilder::create()
+        ->setCredentials('test', 'secret')
+        ->setLogger($logger)
+        ->build();
+
+    expect($client->getLogger())->toBe($logger);
+});

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Farzai\Bitkub\Client;
 use Farzai\Bitkub\ClientBuilder;
 use Farzai\Bitkub\Exceptions\InvalidArgumentException;

--- a/tests/ErrorCodesTest.php
+++ b/tests/ErrorCodesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Farzai\Bitkub\Constants\ErrorCodes;
 
 it('should see all error codes', function () {

--- a/tests/ErrorCodesTest.php
+++ b/tests/ErrorCodesTest.php
@@ -12,3 +12,22 @@ it('should return message from code success', function () {
     expect(ErrorCodes::getDescription(ErrorCodes::INVALID_USER))
         ->toBe('Invalid user');
 });
+
+it('should return unknown error code message for unrecognized code', function () {
+    expect(ErrorCodes::getDescription(9999))
+        ->toBe('Unknown error code: 9999');
+});
+
+it('should return correct descriptions for all known codes', function () {
+    expect(ErrorCodes::getDescription(ErrorCodes::NO_ERROR))->toBe('No error');
+    expect(ErrorCodes::getDescription(ErrorCodes::SERVER_ERROR))->toBe('Server error (please contact support)');
+    expect(ErrorCodes::getDescription(ErrorCodes::INSUFFICIENT_BALANCE))->toBe('Insufficient balance');
+});
+
+it('all() includes both constant values and the DESCRIPTIONS array', function () {
+    $all = ErrorCodes::all();
+
+    expect($all)->toContain(ErrorCodes::NO_ERROR);
+    expect($all)->toContain(ErrorCodes::INVALID_JSON_PAYLOAD);
+    expect($all)->toContain(ErrorCodes::SERVER_ERROR);
+});

--- a/tests/GenerateSignatureV3Test.php
+++ b/tests/GenerateSignatureV3Test.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+use Farzai\Bitkub\ClientBuilder;
+use Farzai\Bitkub\Requests\GenerateSignatureV3;
+use Farzai\Bitkub\Tests\MockHttpClient;
+
+it('applies signature headers to request', function () {
+    $psrClient = MockHttpClient::make()
+        ->addSequence(fn ($client) => MockHttpClient::responseServerTimestamp());
+
+    $client = ClientBuilder::create()
+        ->setCredentials('my-api-key', 'my-secret')
+        ->setHttpClient($psrClient)
+        ->build();
+
+    $config = $client->getConfig();
+    $interceptor = new GenerateSignatureV3($config, $client);
+
+    // Build a simple request
+    $request = (new \Farzai\Transport\RequestBuilder)
+        ->method('POST')
+        ->uri('/api/v3/market/balances')
+        ->build();
+
+    $signedRequest = $interceptor->apply($request);
+
+    expect($signedRequest->getHeaderLine('X-BTK-APIKEY'))->toBe('my-api-key');
+    expect($signedRequest->getHeaderLine('X-BTK-SIGN'))->not->toBeEmpty();
+    expect($signedRequest->getHeaderLine('X-BTK-TIMESTAMP'))->not->toBeEmpty();
+});
+
+it('applies signature with query string present', function () {
+    $psrClient = MockHttpClient::make()
+        ->addSequence(fn ($client) => MockHttpClient::responseServerTimestamp());
+
+    $client = ClientBuilder::create()
+        ->setCredentials('my-api-key', 'my-secret')
+        ->setHttpClient($psrClient)
+        ->build();
+
+    $config = $client->getConfig();
+    $interceptor = new GenerateSignatureV3($config, $client);
+
+    // Build a request with query params
+    $request = (new \Farzai\Transport\RequestBuilder)
+        ->method('GET')
+        ->uri('/api/v3/market/my-open-orders')
+        ->withQuery(['sym' => 'THB_BTC'])
+        ->build();
+
+    $signedRequest = $interceptor->apply($request);
+
+    expect($signedRequest->getHeaderLine('X-BTK-APIKEY'))->toBe('my-api-key');
+    expect($signedRequest->getHeaderLine('X-BTK-SIGN'))->not->toBeEmpty();
+    // Signature should differ from a request without query
+    $signedRequest2 = $interceptor->apply(
+        (new \Farzai\Transport\RequestBuilder)
+            ->method('GET')
+            ->uri('/api/v3/market/my-open-orders')
+            ->build()
+    );
+
+    expect($signedRequest->getHeaderLine('X-BTK-SIGN'))
+        ->not->toBe($signedRequest2->getHeaderLine('X-BTK-SIGN'));
+});
+
+it('applies signature with request body', function () {
+    $psrClient = MockHttpClient::make()
+        ->addSequence(fn ($client) => MockHttpClient::responseServerTimestamp());
+
+    $client = ClientBuilder::create()
+        ->setCredentials('my-api-key', 'my-secret')
+        ->setHttpClient($psrClient)
+        ->build();
+
+    $config = $client->getConfig();
+    $interceptor = new GenerateSignatureV3($config, $client);
+
+    // Build a request with a body
+    $request = (new \Farzai\Transport\RequestBuilder)
+        ->method('POST')
+        ->uri('/api/v3/market/place-bid')
+        ->withJson(['sym' => 'THB_BTC', 'amt' => 1000, 'rat' => 15000, 'typ' => 'limit'])
+        ->build();
+
+    $signedRequest = $interceptor->apply($request);
+
+    expect($signedRequest->getHeaderLine('X-BTK-APIKEY'))->toBe('my-api-key');
+    expect($signedRequest->getHeaderLine('X-BTK-SIGN'))->not->toBeEmpty();
+    expect($signedRequest->getHeaderLine('X-BTK-TIMESTAMP'))->not->toBeEmpty();
+});
+
+it('reuses timestamp within sync interval', function () {
+    $psrClient = MockHttpClient::make()
+        ->addSequence(fn ($client) => MockHttpClient::responseServerTimestamp());
+
+    $client = ClientBuilder::create()
+        ->setCredentials('my-api-key', 'my-secret')
+        ->setHttpClient($psrClient)
+        ->build();
+
+    $config = $client->getConfig();
+    $interceptor = new GenerateSignatureV3($config, $client);
+
+    $request = (new \Farzai\Transport\RequestBuilder)
+        ->method('POST')
+        ->uri('/api/v3/market/balances')
+        ->build();
+
+    // First call syncs with server
+    $signed1 = $interceptor->apply($request);
+
+    // Second call should reuse the cached drift (no second HTTP call needed)
+    $signed2 = $interceptor->apply($request);
+
+    expect($signed1->getHeaderLine('X-BTK-APIKEY'))->toBe('my-api-key');
+    expect($signed2->getHeaderLine('X-BTK-APIKEY'))->toBe('my-api-key');
+});

--- a/tests/MockHttpClient.php
+++ b/tests/MockHttpClient.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Farzai\Bitkub\Tests;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/MockHttpClient.php
+++ b/tests/MockHttpClient.php
@@ -18,6 +18,11 @@ class MockHttpClient extends TestCase implements PsrClientInterface
     private array $sequence = [];
 
     /**
+     * @var array<int, PsrRequestInterface>
+     */
+    private array $recordedRequests = [];
+
+    /**
      * Create a new mock http client instance.
      */
     public static function make(): self
@@ -48,13 +53,34 @@ class MockHttpClient extends TestCase implements PsrClientInterface
      */
     public function sendRequest(PsrRequestInterface $request): PsrResponseInterface
     {
+        $this->recordedRequests[] = $request;
+
+        if (empty($this->sequence)) {
+            throw new \RuntimeException('No more mock responses in the sequence. Did you forget to add mock responses?');
+        }
+
         return array_shift($this->sequence);
+    }
+
+    /**
+     * @return array<int, PsrRequestInterface>
+     */
+    public function getRecordedRequests(): array
+    {
+        return $this->recordedRequests;
+    }
+
+    public function getLastRequest(): ?PsrRequestInterface
+    {
+        return end($this->recordedRequests) ?: null;
     }
 
     public function createStream(string $contents): PsrStreamInterface
     {
         $stream = $this->createMock(PsrStreamInterface::class);
         $stream->method('getContents')->willReturn($contents);
+        $stream->method('__toString')->willReturn($contents);
+        $stream->method('rewind')->willReturnCallback(function () {});
 
         return $stream;
     }

--- a/tests/PendingRequestTest.php
+++ b/tests/PendingRequestTest.php
@@ -210,3 +210,95 @@ it('can createResponse wrapping PSR response', function () {
     expect($response)->toBeInstanceOf(\Farzai\Bitkub\Responses\ResponseWithValidateErrorCode::class);
     expect($response->statusCode())->toBe(200);
 });
+
+it('can send request with interceptors applied', function () {
+    $psrClient = \Farzai\Bitkub\Tests\MockHttpClient::make()
+        ->addSequence(\Farzai\Bitkub\Tests\MockHttpClient::response(200, json_encode([
+            'error' => 0,
+            'result' => 'ok',
+        ])));
+
+    $client = ClientBuilder::create()
+        ->setCredentials('test', 'secret')
+        ->setHttpClient($psrClient)
+        ->build();
+
+    $interceptorCalled = false;
+    $interceptor = $this->createMock(\Farzai\Bitkub\Contracts\RequestInterceptor::class);
+    $interceptor->method('apply')->willReturnCallback(function ($request) use (&$interceptorCalled) {
+        $interceptorCalled = true;
+
+        return $request->withHeader('X-Custom', 'test');
+    });
+
+    $pending = new PendingRequest($client, 'GET', '/api/market/symbols');
+    $response = $pending->withInterceptor($interceptor)->send();
+
+    expect($interceptorCalled)->toBeTrue();
+    expect($response)->toBeInstanceOf(\Farzai\Transport\Contracts\ResponseInterface::class);
+    expect($response->json('result'))->toBe('ok');
+});
+
+it('can send request with multiple interceptors applied in order', function () {
+    $psrClient = \Farzai\Bitkub\Tests\MockHttpClient::make()
+        ->addSequence(\Farzai\Bitkub\Tests\MockHttpClient::response(200, json_encode([
+            'error' => 0,
+        ])));
+
+    $client = ClientBuilder::create()
+        ->setCredentials('test', 'secret')
+        ->setHttpClient($psrClient)
+        ->build();
+
+    $order = [];
+
+    $interceptor1 = $this->createMock(\Farzai\Bitkub\Contracts\RequestInterceptor::class);
+    $interceptor1->method('apply')->willReturnCallback(function ($request) use (&$order) {
+        $order[] = 'first';
+
+        return $request;
+    });
+
+    $interceptor2 = $this->createMock(\Farzai\Bitkub\Contracts\RequestInterceptor::class);
+    $interceptor2->method('apply')->willReturnCallback(function ($request) use (&$order) {
+        $order[] = 'second';
+
+        return $request;
+    });
+
+    $pending = new PendingRequest($client, 'GET', '/api/market/symbols');
+    $pending->withInterceptor($interceptor1)->withInterceptor($interceptor2)->send();
+
+    expect($order)->toBe(['first', 'second']);
+});
+
+it('withHeaders merges with existing headers', function () {
+    $client = ClientBuilder::create()
+        ->setCredentials('test', 'secret')
+        ->build();
+
+    $pending = new PendingRequest($client, 'GET', '/api/market/balances');
+    $pending->withHeaders(['X-First' => 'one']);
+    $pending->withHeaders(['X-Second' => 'two']);
+
+    $request = $pending->createRequest('GET', '/api/market/balances', [
+        'headers' => ['X-First' => 'one', 'X-Second' => 'two'],
+    ]);
+
+    expect($request->getHeaderLine('X-First'))->toBe('one');
+    expect($request->getHeaderLine('X-Second'))->toBe('two');
+});
+
+it('createRequest with empty query array omits query string', function () {
+    $client = ClientBuilder::create()
+        ->setCredentials('test', 'secret')
+        ->build();
+
+    $pending = new PendingRequest($client, 'GET', '/api/market/ticker');
+
+    $request = $pending->createRequest('GET', '/api/market/ticker', [
+        'query' => [],
+    ]);
+
+    expect($request->getUri()->getQuery())->toBe('');
+});

--- a/tests/PendingRequestTest.php
+++ b/tests/PendingRequestTest.php
@@ -19,9 +19,9 @@ it('can set request method', function () {
         ->build();
 
     $request = new PendingRequest($client, 'GET', '/api/market/balances');
-    $request->method('POST');
+    $result = $request->method('POST');
 
-    expect($request->method)->toBe('POST');
+    expect($result)->toBeInstanceOf(PendingRequest::class);
 });
 
 it('can set request path', function () {
@@ -30,9 +30,9 @@ it('can set request path', function () {
         ->build();
 
     $request = new PendingRequest($client, 'GET', '/api/market/balances');
-    $request->path('/api/market/orders');
+    $result = $request->path('/api/market/orders');
 
-    expect($request->path)->toBe('/api/market/orders');
+    expect($result)->toBeInstanceOf(PendingRequest::class);
 });
 
 it('can set request options', function () {
@@ -41,9 +41,9 @@ it('can set request options', function () {
         ->build();
 
     $request = new PendingRequest($client, 'GET', '/api/market/balances');
-    $request->options(['query' => ['symbol' => 'BTC']]);
+    $result = $request->options(['query' => ['symbol' => 'BTC']]);
 
-    expect($request->options)->toBe(['query' => ['symbol' => 'BTC']]);
+    expect($result)->toBeInstanceOf(PendingRequest::class);
 });
 
 it('can add request interceptor', function () {
@@ -51,16 +51,16 @@ it('can add request interceptor', function () {
         ->setCredentials('test', 'secret')
         ->build();
 
-    $request = $this->createMock(\Psr\Http\Message\RequestInterface::class);
+    $mockRequest = $this->createMock(\Psr\Http\Message\RequestInterface::class);
 
     $pending = new PendingRequest($client, 'GET', '/api/market/balances');
 
     $interceptor = $this->createMock(\Farzai\Bitkub\Contracts\RequestInterceptor::class);
-    $interceptor->method('apply')->willReturn($request);
+    $interceptor->method('apply')->willReturn($mockRequest);
 
-    $pending->withInterceptor($interceptor);
+    $result = $pending->withInterceptor($interceptor);
 
-    expect($pending->interceptors)->toContain($interceptor);
+    expect($result)->toBeInstanceOf(PendingRequest::class);
 });
 
 it('can set request body', function () {
@@ -69,9 +69,9 @@ it('can set request body', function () {
         ->build();
 
     $request = new PendingRequest($client, 'POST', '/api/market/orders');
-    $request->withBody(['symbol' => 'BTC', 'quantity' => 1]);
+    $result = $request->withBody(['symbol' => 'BTC', 'quantity' => 1]);
 
-    expect($request->options['body'])->toBe(['symbol' => 'BTC', 'quantity' => 1]);
+    expect($result)->toBeInstanceOf(PendingRequest::class);
 });
 
 it('can set request query', function () {
@@ -80,9 +80,9 @@ it('can set request query', function () {
         ->build();
 
     $request = new PendingRequest($client, 'GET', '/api/market/balances');
-    $request->withQuery(['symbol' => 'BTC']);
+    $result = $request->withQuery(['symbol' => 'BTC']);
 
-    expect($request->options['query'])->toBe(['symbol' => 'BTC']);
+    expect($result)->toBeInstanceOf(PendingRequest::class);
 });
 
 it('can set request headers', function () {
@@ -91,9 +91,9 @@ it('can set request headers', function () {
         ->build();
 
     $request = new PendingRequest($client, 'GET', '/api/market/balances');
-    $request->withHeaders(['Authorization' => 'Bearer token']);
+    $result = $request->withHeaders(['Authorization' => 'Bearer token']);
 
-    expect($request->options['headers'])->toBe(['Authorization' => 'Bearer token']);
+    expect($result)->toBeInstanceOf(PendingRequest::class);
 });
 
 it('can set request header', function () {
@@ -102,9 +102,9 @@ it('can set request header', function () {
         ->build();
 
     $request = new PendingRequest($client, 'GET', '/api/market/balances');
-    $request->withHeader('Content-Type', 'application/json');
+    $result = $request->withHeader('Content-Type', 'application/json');
 
-    expect($request->options['headers']['Content-Type'])->toBe('application/json');
+    expect($result)->toBeInstanceOf(PendingRequest::class);
 });
 
 it('can set request to accept JSON', function () {
@@ -113,9 +113,9 @@ it('can set request to accept JSON', function () {
         ->build();
 
     $request = new PendingRequest($client, 'GET', '/api/market/balances');
-    $request->acceptJson();
+    $result = $request->acceptJson();
 
-    expect($request->options['headers']['Accept'])->toBe('application/json');
+    expect($result)->toBeInstanceOf(PendingRequest::class);
 });
 
 it('can set request to send JSON', function () {
@@ -124,9 +124,9 @@ it('can set request to send JSON', function () {
         ->build();
 
     $request = new PendingRequest($client, 'POST', '/api/market/orders');
-    $request->asJson();
+    $result = $request->asJson();
 
-    expect($request->options['headers']['Content-Type'])->toBe('application/json');
+    expect($result)->toBeInstanceOf(PendingRequest::class);
 });
 
 it('it can createRequest success', function () {

--- a/tests/PendingRequestTest.php
+++ b/tests/PendingRequestTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Farzai\Bitkub\ClientBuilder;
 use Farzai\Bitkub\Requests\PendingRequest;
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,7 +1,6 @@
 <?php
 
+declare(strict_types=1);
+
 uses()
-    ->beforeEach(function () {
-        \Farzai\Bitkub\Requests\GenerateSignatureV3::resetTimestampCache();
-    })
     ->in(__DIR__);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,1 +1,7 @@
 <?php
+
+uses()
+    ->beforeEach(function () {
+        \Farzai\Bitkub\Requests\GenerateSignatureV3::resetTimestampCache();
+    })
+    ->in(__DIR__);

--- a/tests/ResponseErrorCodeTest.php
+++ b/tests/ResponseErrorCodeTest.php
@@ -71,13 +71,16 @@ it('should valid response if response without farzai response', function () {
     expect($exception->getResponse())->toBe($psrResponse);
 });
 
-it('should be error code not found', function () {
+it('should handle missing error code gracefully', function () {
     $psrResponse = MockHttpClient::response(200, json_encode([
         // Empty error code
     ]));
 
-    new BitkubResponseErrorCodeException($psrResponse);
-})->throws(\Exception::class, 'Error code not found.');
+    $exception = new BitkubResponseErrorCodeException($psrResponse);
+
+    expect($exception->getMessage())->toBe('Malformed response: error code not found.');
+    expect($exception->getCode())->toBe(0);
+});
 
 it('should not throw exception when error code is null', function () {
     $psrRequest = $this->createMock(PsrRequestInterface::class);
@@ -142,6 +145,38 @@ it('decorator delegates PSR-7 getStatusCode', function () {
     $response = new ResponseWithValidateErrorCode($response);
 
     expect($response->getStatusCode())->toBe(201);
+});
+
+it('throw with custom callback still validates error codes', function () {
+    $psrRequest = $this->createMock(PsrRequestInterface::class);
+    $psrResponse = MockHttpClient::response(200, json_encode([
+        'error' => 1,
+    ]));
+
+    $response = new Response($psrRequest, $psrResponse);
+    $response = new ResponseWithValidateErrorCode($response);
+
+    $callbackCalled = false;
+    $response->throw(function () use (&$callbackCalled) {
+        $callbackCalled = true;
+    });
+})->throws(BitkubResponseErrorCodeException::class, 'Invalid JSON payload');
+
+it('throw with custom callback is called when no error', function () {
+    $psrRequest = $this->createMock(PsrRequestInterface::class);
+    $psrResponse = MockHttpClient::response(200, json_encode([
+        'error' => 0,
+    ]));
+
+    $response = new Response($psrRequest, $psrResponse);
+    $response = new ResponseWithValidateErrorCode($response);
+
+    $callbackCalled = false;
+    $response->throw(function () use (&$callbackCalled) {
+        $callbackCalled = true;
+    });
+
+    expect($callbackCalled)->toBeTrue();
 });
 
 it('decorator delegates PSR-7 getBody', function () {

--- a/tests/ResponseErrorCodeTest.php
+++ b/tests/ResponseErrorCodeTest.php
@@ -190,3 +190,77 @@ it('decorator delegates PSR-7 getBody', function () {
 
     expect($response->getBody())->toBeInstanceOf(\Psr\Http\Message\StreamInterface::class);
 });
+
+it('decorator delegates getReasonPhrase', function () {
+    $psrRequest = $this->createMock(PsrRequestInterface::class);
+    $psrResponse = MockHttpClient::response(200, json_encode(['error' => 0]));
+
+    $response = new Response($psrRequest, $psrResponse);
+    $response = new ResponseWithValidateErrorCode($response);
+
+    expect($response->getReasonPhrase())->toBeString();
+});
+
+it('decorator delegates getProtocolVersion', function () {
+    $psrRequest = $this->createMock(PsrRequestInterface::class);
+    $psrResponse = MockHttpClient::response(200, json_encode(['error' => 0]));
+
+    $response = new Response($psrRequest, $psrResponse);
+    $response = new ResponseWithValidateErrorCode($response);
+
+    expect($response->getProtocolVersion())->toBeString();
+});
+
+it('decorator delegates getHeaders via PSR-7', function () {
+    $psrRequest = $this->createMock(PsrRequestInterface::class);
+    $psrResponse = MockHttpClient::response(200, json_encode(['error' => 0]), [
+        'Content-Type' => 'application/json',
+    ]);
+
+    $response = new Response($psrRequest, $psrResponse);
+    $response = new ResponseWithValidateErrorCode($response);
+
+    expect($response->getHeaders())->toBeArray();
+});
+
+it('decorator delegates hasHeader', function () {
+    $psrRequest = $this->createMock(PsrRequestInterface::class);
+    $psrResponse = MockHttpClient::response(200, json_encode(['error' => 0]));
+
+    $response = new Response($psrRequest, $psrResponse);
+    $response = new ResponseWithValidateErrorCode($response);
+
+    // The mock may or may not have headers, but hasHeader should return a bool
+    expect($response->hasHeader('Content-Type'))->toBeBool();
+});
+
+it('decorator delegates getHeader', function () {
+    $psrRequest = $this->createMock(PsrRequestInterface::class);
+    $psrResponse = MockHttpClient::response(200, json_encode(['error' => 0]));
+
+    $response = new Response($psrRequest, $psrResponse);
+    $response = new ResponseWithValidateErrorCode($response);
+
+    expect($response->getHeader('Content-Type'))->toBeArray();
+});
+
+it('decorator delegates getHeaderLine', function () {
+    $psrRequest = $this->createMock(PsrRequestInterface::class);
+    $psrResponse = MockHttpClient::response(200, json_encode(['error' => 0]));
+
+    $response = new Response($psrRequest, $psrResponse);
+    $response = new ResponseWithValidateErrorCode($response);
+
+    expect($response->getHeaderLine('Content-Type'))->toBeString();
+});
+
+it('exception with unknown error code uses fallback message', function () {
+    $psrResponse = MockHttpClient::response(200, json_encode([
+        'error' => 12345,
+    ]));
+
+    $exception = new BitkubResponseErrorCodeException($psrResponse);
+
+    expect($exception->getCode())->toBe(12345);
+    expect($exception->getMessage())->toBe('Unknown error code: 12345');
+});

--- a/tests/ResponseErrorCodeTest.php
+++ b/tests/ResponseErrorCodeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Farzai\Bitkub\Constants\ErrorCodes;
 use Farzai\Bitkub\Exceptions\BitkubResponseErrorCodeException;
 use Farzai\Bitkub\Responses\ResponseWithValidateErrorCode;

--- a/tests/RestApiTest/AbstractEndpointTest.php
+++ b/tests/RestApiTest/AbstractEndpointTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+use Farzai\Bitkub\ClientBuilder;
+use Farzai\Bitkub\Endpoints\MarketEndpoint;
+
+it('filterParams strips null values', function () {
+    $client = ClientBuilder::create()
+        ->setCredentials('test', 'secret')
+        ->build();
+
+    $endpoint = new MarketEndpoint($client);
+
+    // Use reflection to test the protected filterParams method
+    $reflection = new ReflectionMethod($endpoint, 'filterParams');
+
+    $result = $reflection->invoke($endpoint, [
+        'sym' => 'THB_BTC',
+        'lmt' => null,
+        'page' => 1,
+    ]);
+
+    expect($result)->toBe([
+        'sym' => 'THB_BTC',
+        'page' => 1,
+    ]);
+});
+
+it('filterParams strips empty string values', function () {
+    $client = ClientBuilder::create()
+        ->setCredentials('test', 'secret')
+        ->build();
+
+    $endpoint = new MarketEndpoint($client);
+
+    $reflection = new ReflectionMethod($endpoint, 'filterParams');
+
+    $result = $reflection->invoke($endpoint, [
+        'sym' => 'THB_BTC',
+        'lmt' => '',
+        'page' => 0,
+    ]);
+
+    expect($result)->toBe([
+        'sym' => 'THB_BTC',
+        'page' => 0,
+    ]);
+});
+
+it('filterParams keeps zero and false values', function () {
+    $client = ClientBuilder::create()
+        ->setCredentials('test', 'secret')
+        ->build();
+
+    $endpoint = new MarketEndpoint($client);
+
+    $reflection = new ReflectionMethod($endpoint, 'filterParams');
+
+    $result = $reflection->invoke($endpoint, [
+        'sym' => 'THB_BTC',
+        'lmt' => 0,
+        'active' => false,
+        'empty' => null,
+        'blank' => '',
+    ]);
+
+    expect($result)->toHaveKey('sym');
+    expect($result)->toHaveKey('lmt');
+    expect($result)->toHaveKey('active');
+    expect($result)->not->toHaveKey('empty');
+    expect($result)->not->toHaveKey('blank');
+});
+
+it('filterParams returns empty array from all-null input', function () {
+    $client = ClientBuilder::create()
+        ->setCredentials('test', 'secret')
+        ->build();
+
+    $endpoint = new MarketEndpoint($client);
+
+    $reflection = new ReflectionMethod($endpoint, 'filterParams');
+
+    $result = $reflection->invoke($endpoint, [
+        'a' => null,
+        'b' => '',
+    ]);
+
+    expect($result)->toBe([]);
+});

--- a/tests/RestApiTest/CryptoEndpointTest.php
+++ b/tests/RestApiTest/CryptoEndpointTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Farzai\Bitkub\ClientBuilder;
 use Farzai\Bitkub\Endpoints\CryptoEndpoint;
 use Farzai\Bitkub\Tests\MockHttpClient;

--- a/tests/RestApiTest/MarketEndpointTest.php
+++ b/tests/RestApiTest/MarketEndpointTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Farzai\Bitkub\ClientBuilder;
 use Farzai\Bitkub\Endpoints\MarketEndpoint;
 use Farzai\Bitkub\Tests\MockHttpClient;

--- a/tests/RestApiTest/MarketEndpointTest.php
+++ b/tests/RestApiTest/MarketEndpointTest.php
@@ -352,6 +352,123 @@ it('should call placeAsk success', function () {
     expect($response->json('result.hash'))->toBe('fwQ6dnQWQPs4cbatF5Am2xCDP1J');
 });
 
+it('should get openOrders success', function () {
+    $psrClient = MockHttpClient::make()
+        ->addSequence(fn ($client) => MockHttpClient::responseServerTimestamp())
+        ->addSequence(fn ($client) => $client->createResponse(200, json_encode([
+            'error' => 0,
+            'result' => [
+                [
+                    'id' => '2',
+                    'hash' => 'fwQ6dnQWQPs4cbatFSJpMCcKTFR',
+                    'side' => 'SELL',
+                    'type' => 'limit',
+                    'rate' => 15000,
+                    'fee' => 35.01,
+                    'credit' => 35.01,
+                    'amount' => 0.93333334,
+                    'receive' => 14000,
+                    'parent_id' => 1,
+                    'super_id' => 1,
+                    'ts' => 1533834844,
+                ],
+            ],
+        ])));
+
+    $client = ClientBuilder::create()
+        ->setCredentials('test', 'secret')
+        ->setHttpClient($psrClient)
+        ->build();
+
+    $market = $client->market();
+
+    $response = $market->openOrders('THB_BTC');
+
+    expect($response)->toBeInstanceOf(ResponseInterface::class);
+    expect($response->json('result.0.id'))->toBe('2');
+    expect($response->json('result.0.side'))->toBe('SELL');
+});
+
+it('should get myOrderHistory success', function () {
+    $psrClient = MockHttpClient::make()
+        ->addSequence(fn ($client) => MockHttpClient::responseServerTimestamp())
+        ->addSequence(fn ($client) => $client->createResponse(200, json_encode([
+            'error' => 0,
+            'result' => [
+                [
+                    'txn_id' => 'ETHBUY0000000197',
+                    'order_id' => '240',
+                    'hash' => 'fwQ6dnQWQPs4cbaujNyejinS43a',
+                    'side' => 'buy',
+                    'type' => 'limit',
+                    'rate' => '13335.57',
+                    'fee' => '0.34',
+                    'credit' => '0.34',
+                    'amount' => '0.00999987',
+                    'ts' => 1531513395,
+                ],
+            ],
+            'pagination' => [
+                'page' => 1,
+                'last' => 1,
+            ],
+        ])));
+
+    $client = ClientBuilder::create()
+        ->setCredentials('test', 'secret')
+        ->setHttpClient($psrClient)
+        ->build();
+
+    $market = $client->market();
+
+    $response = $market->myOrderHistory([
+        'sym' => 'THB_ETH',
+        'p' => 1,
+        'lmt' => 10,
+    ]);
+
+    expect($response)->toBeInstanceOf(ResponseInterface::class);
+    expect($response->json('result.0.txn_id'))->toBe('ETHBUY0000000197');
+});
+
+it('should get myOrderInfo success', function () {
+    $psrClient = MockHttpClient::make()
+        ->addSequence(fn ($client) => MockHttpClient::responseServerTimestamp())
+        ->addSequence(fn ($client) => $client->createResponse(200, json_encode([
+            'error' => 0,
+            'result' => [
+                'id' => '289',
+                'first' => '289',
+                'parent' => '0',
+                'last' => '316',
+                'amount' => 4000,
+                'rate' => 291000,
+                'fee' => 10,
+                'credit' => 10,
+                'filled' => 3999.97,
+                'total' => 4000,
+                'status' => 'filled',
+            ],
+        ])));
+
+    $client = ClientBuilder::create()
+        ->setCredentials('test', 'secret')
+        ->setHttpClient($psrClient)
+        ->build();
+
+    $market = $client->market();
+
+    $response = $market->myOrderInfo([
+        'sym' => 'THB_BTC',
+        'id' => '289',
+        'sd' => 'buy',
+    ]);
+
+    expect($response)->toBeInstanceOf(ResponseInterface::class);
+    expect($response->json('result.id'))->toBe('289');
+    expect($response->json('result.status'))->toBe('filled');
+});
+
 it('should call cancelOrder success', function () {
     $psrClient = MockHttpClient::make()
         ->addSequence(fn ($client) => MockHttpClient::responseServerTimestamp())

--- a/tests/RestApiTest/MarketEndpointTest.php
+++ b/tests/RestApiTest/MarketEndpointTest.php
@@ -471,6 +471,82 @@ it('should get myOrderInfo success', function () {
     expect($response->json('result.status'))->toBe('filled');
 });
 
+it('should get ticker with symbol param success', function () {
+    $psrClient = MockHttpClient::make()
+        ->addSequence(fn ($client) => $client->createResponse(200, json_encode([
+            'THB_BTC' => [
+                'id' => 1,
+                'last' => 216415.00,
+                'lowestAsk' => 216678.00,
+                'highestBid' => 215000.00,
+                'percentChange' => 1.91,
+                'baseVolume' => 71.02603946,
+                'quoteVolume' => 15302897.99,
+                'isFrozen' => 0,
+                'high24hr' => 221396.00,
+                'low24hr' => 206414.00,
+            ],
+        ])));
+
+    $client = ClientBuilder::create()
+        ->setCredentials('test', 'secret')
+        ->setHttpClient($psrClient)
+        ->build();
+
+    $market = $client->market();
+
+    $response = $market->ticker('THB_BTC');
+
+    expect($response)->toBeInstanceOf(ResponseInterface::class);
+    expect($response->json('THB_BTC.id'))->toBe(1);
+});
+
+it('should handle trades with null params without error', function () {
+    $psrClient = MockHttpClient::make()
+        ->addSequence(fn ($client) => $client->createResponse(200, json_encode([
+            'error' => 0,
+            'result' => [],
+        ])));
+
+    $client = ClientBuilder::create()
+        ->setCredentials('test', 'secret')
+        ->setHttpClient($psrClient)
+        ->build();
+
+    $market = $client->market();
+
+    $response = $market->trades([
+        'sym' => 'THB_BTC',
+        'lmt' => null,
+    ]);
+
+    expect($response)->toBeInstanceOf(ResponseInterface::class);
+    expect($response->json('error'))->toBe(0);
+});
+
+it('should handle trades with empty string params without error', function () {
+    $psrClient = MockHttpClient::make()
+        ->addSequence(fn ($client) => $client->createResponse(200, json_encode([
+            'error' => 0,
+            'result' => [],
+        ])));
+
+    $client = ClientBuilder::create()
+        ->setCredentials('test', 'secret')
+        ->setHttpClient($psrClient)
+        ->build();
+
+    $market = $client->market();
+
+    $response = $market->trades([
+        'sym' => 'THB_BTC',
+        'lmt' => '',
+    ]);
+
+    expect($response)->toBeInstanceOf(ResponseInterface::class);
+    expect($response->json('error'))->toBe(0);
+});
+
 it('should call cancelOrder success', function () {
     $psrClient = MockHttpClient::make()
         ->addSequence(fn ($client) => MockHttpClient::responseServerTimestamp())

--- a/tests/RestApiTest/SystemEndpointTest.php
+++ b/tests/RestApiTest/SystemEndpointTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Farzai\Bitkub\ClientBuilder;
 use Farzai\Bitkub\Endpoints\SystemEndpoint;
 use Farzai\Bitkub\Tests\MockHttpClient;

--- a/tests/RestApiTest/UserEndpointTest.php
+++ b/tests/RestApiTest/UserEndpointTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Farzai\Bitkub\ClientBuilder;
 use Farzai\Bitkub\Endpoints\UserEndpoint;
 use Farzai\Bitkub\Tests\MockHttpClient;

--- a/tests/UriFactoryTest.php
+++ b/tests/UriFactoryTest.php
@@ -11,3 +11,28 @@ it('can create uri', function () {
     expect($uri->getHost())->toBe('api.bitkub.com');
     expect($uri->getPath())->toBe('');
 });
+
+it('can create uri with path, query, and port', function () {
+    $uri = UriFactory::createFromUri('https://api.bitkub.com:8443/api/v3/market?sym=THB_BTC');
+
+    expect($uri->getScheme())->toBe('https');
+    expect($uri->getHost())->toBe('api.bitkub.com');
+    expect($uri->getPort())->toBe(8443);
+    expect($uri->getPath())->toBe('/api/v3/market');
+    expect($uri->getQuery())->toBe('sym=THB_BTC');
+});
+
+it('can create uri with fragment', function () {
+    $uri = UriFactory::createFromUri('https://api.bitkub.com/docs#section');
+
+    expect($uri->getPath())->toBe('/docs');
+    expect($uri->getFragment())->toBe('section');
+});
+
+it('can create uri with http scheme', function () {
+    $uri = UriFactory::createFromUri('http://localhost:3000/api');
+
+    expect($uri->getScheme())->toBe('http');
+    expect($uri->getHost())->toBe('localhost');
+    expect($uri->getPort())->toBe(3000);
+});

--- a/tests/UriFactoryTest.php
+++ b/tests/UriFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Farzai\Bitkub\UriFactory;
 
 it('can create uri', function () {

--- a/tests/WebSocketTests/EngineTest.php
+++ b/tests/WebSocketTests/EngineTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use Farzai\Bitkub\Tests\WebSocketTests\MockWebSocketEngine;
+use Farzai\Bitkub\WebSocket\Message;
+
+it('dispatches message to correct listener', function () {
+    $engine = new MockWebSocketEngine;
+    $engine->addMessage('market.trade.thb_btc', ['price' => 100]);
+
+    $received = [];
+    $listeners = [
+        'market.trade.thb_btc' => [
+            function (Message $m) use (&$received) {
+                $received[] = $m->json('price');
+            },
+        ],
+    ];
+
+    $engine->handle($listeners);
+
+    expect($received)->toBe([100]);
+});
+
+it('dispatches to multiple listeners for same stream', function () {
+    $engine = new MockWebSocketEngine;
+    $engine->addMessage('market.trade.thb_btc', ['price' => 200]);
+
+    $calls = 0;
+    $listeners = [
+        'market.trade.thb_btc' => [
+            function (Message $m) use (&$calls) {
+                $calls++;
+            },
+            function (Message $m) use (&$calls) {
+                $calls++;
+            },
+        ],
+    ];
+
+    $engine->handle($listeners);
+
+    expect($calls)->toBe(2);
+});
+
+it('ignores messages for unregistered streams', function () {
+    $engine = new MockWebSocketEngine;
+    $engine->addMessage('market.trade.thb_eth', ['price' => 300]);
+
+    $received = [];
+    $listeners = [
+        'market.trade.thb_btc' => [
+            function (Message $m) use (&$received) {
+                $received[] = $m->json('price');
+            },
+        ],
+    ];
+
+    $engine->handle($listeners);
+
+    expect($received)->toBe([]);
+});
+
+it('dispatches messages with pre-decoded data', function () {
+    $engine = new MockWebSocketEngine;
+    $engine->addMessage('market.trade.thb_btc', ['price' => 500, 'vol' => 1.5]);
+
+    $received = null;
+    $listeners = [
+        'market.trade.thb_btc' => [
+            function (Message $m) use (&$received) {
+                $received = $m->json();
+            },
+        ],
+    ];
+
+    $engine->handle($listeners);
+
+    expect($received)->toHaveKey('price', 500);
+    expect($received)->toHaveKey('vol', 1.5);
+    expect($received)->toHaveKey('stream', 'market.trade.thb_btc');
+});

--- a/tests/WebSocketTests/EngineTest.php
+++ b/tests/WebSocketTests/EngineTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Farzai\Bitkub\Tests\WebSocketTests\MockWebSocketEngine;
 use Farzai\Bitkub\WebSocket\Message;
 

--- a/tests/WebSocketTests/LiveOrderBookEndpointTest.php
+++ b/tests/WebSocketTests/LiveOrderBookEndpointTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Farzai\Bitkub\ClientBuilder;
 use Farzai\Bitkub\Tests\MockHttpClient;
 use Farzai\Bitkub\Tests\WebSocketTests\MockWebSocketEngine;

--- a/tests/WebSocketTests/LiveOrderBookEndpointTest.php
+++ b/tests/WebSocketTests/LiveOrderBookEndpointTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use Farzai\Bitkub\ClientBuilder;
+use Farzai\Bitkub\Tests\MockHttpClient;
+use Farzai\Bitkub\Tests\WebSocketTests\MockWebSocketEngine;
+use Farzai\Bitkub\WebSocket\Endpoints\LiveOrderBookEndpoint;
+use Farzai\Bitkub\WebSocketClient;
+
+it('throws RuntimeException when no REST client and symbol name used', function () {
+    $engine = new MockWebSocketEngine;
+    $client = new WebSocketClient($engine);
+    $endpoint = new LiveOrderBookEndpoint($client);
+
+    $endpoint->listen('thb_btc', function () {});
+})->throws(\RuntimeException::class, 'A REST client is required to resolve symbol names.');
+
+it('accepts numeric symbol ID without REST client', function () {
+    $engine = new MockWebSocketEngine;
+    $client = new WebSocketClient($engine);
+    $endpoint = new LiveOrderBookEndpoint($client);
+
+    $endpoint->listen(1, function () {});
+
+    expect($client->getListeners())->toHaveKey('orderbook/1');
+});
+
+it('caches symbol map per instance not globally', function () {
+    $symbolResponseBody = [
+        'error' => 0,
+        'result' => [
+            ['id' => 1, 'symbol' => 'THB_BTC', 'info' => 'Thai Baht to Bitcoin'],
+            ['id' => 2, 'symbol' => 'THB_ETH', 'info' => 'Thai Baht to Ethereum'],
+        ],
+    ];
+
+    // First instance
+    $httpClient1 = MockHttpClient::make()
+        ->addSequence(MockHttpClient::response(200, json_encode($symbolResponseBody)));
+
+    $baseClient1 = ClientBuilder::create()
+        ->setCredentials('key', 'secret')
+        ->setHttpClient($httpClient1)
+        ->build();
+
+    $engine1 = new MockWebSocketEngine;
+    $wsClient1 = new WebSocketClient($engine1, $baseClient1);
+    $endpoint1 = new LiveOrderBookEndpoint($wsClient1);
+    $endpoint1->listen('thb_btc', function () {});
+
+    // Second instance — should make its own HTTP call (not use static cache)
+    $httpClient2 = MockHttpClient::make()
+        ->addSequence(MockHttpClient::response(200, json_encode($symbolResponseBody)));
+
+    $baseClient2 = ClientBuilder::create()
+        ->setCredentials('key', 'secret')
+        ->setHttpClient($httpClient2)
+        ->build();
+
+    $engine2 = new MockWebSocketEngine;
+    $wsClient2 = new WebSocketClient($engine2, $baseClient2);
+    $endpoint2 = new LiveOrderBookEndpoint($wsClient2);
+    $endpoint2->listen('thb_btc', function () {});
+
+    // Both should have their own listeners
+    expect($wsClient1->getListeners())->toHaveKey('orderbook/1');
+    expect($wsClient2->getListeners())->toHaveKey('orderbook/1');
+});
+
+it('throws for unknown symbol name', function () {
+    $symbolResponseBody = [
+        'error' => 0,
+        'result' => [
+            ['id' => 1, 'symbol' => 'THB_BTC', 'info' => 'Thai Baht to Bitcoin'],
+        ],
+    ];
+
+    $httpClient = MockHttpClient::make()
+        ->addSequence(MockHttpClient::response(200, json_encode($symbolResponseBody)));
+
+    $baseClient = ClientBuilder::create()
+        ->setCredentials('key', 'secret')
+        ->setHttpClient($httpClient)
+        ->build();
+
+    $engine = new MockWebSocketEngine;
+    $client = new WebSocketClient($engine, $baseClient);
+    $endpoint = new LiveOrderBookEndpoint($client);
+
+    $endpoint->listen('thb_unknown', function () {});
+})->throws(\InvalidArgumentException::class, 'Invalid symbol name. Given: thb_unknown');
+
+it('listen returns static for chaining', function () {
+    $engine = new MockWebSocketEngine;
+    $client = new WebSocketClient($engine);
+    $endpoint = new LiveOrderBookEndpoint($client);
+
+    $result = $endpoint->listen(1, function () {});
+
+    expect($result)->toBe($endpoint);
+});

--- a/tests/WebSocketTests/LiveOrderBookEndpointTest.php
+++ b/tests/WebSocketTests/LiveOrderBookEndpointTest.php
@@ -100,3 +100,53 @@ it('listen returns static for chaining', function () {
 
     expect($result)->toBe($endpoint);
 });
+
+it('accepts numeric string as symbol ID', function () {
+    $engine = new MockWebSocketEngine;
+    $client = new WebSocketClient($engine);
+    $endpoint = new LiveOrderBookEndpoint($client);
+
+    $endpoint->listen('42', function () {});
+
+    expect($client->getListeners())->toHaveKey('orderbook/42');
+});
+
+it('resolves symbol names case-insensitively', function () {
+    $symbolResponseBody = [
+        'error' => 0,
+        'result' => [
+            ['id' => 1, 'symbol' => 'THB_BTC', 'info' => 'Thai Baht to Bitcoin'],
+        ],
+    ];
+
+    $httpClient = MockHttpClient::make()
+        ->addSequence(MockHttpClient::response(200, json_encode($symbolResponseBody)));
+
+    $baseClient = ClientBuilder::create()
+        ->setCredentials('key', 'secret')
+        ->setHttpClient($httpClient)
+        ->build();
+
+    $engine = new MockWebSocketEngine;
+    $wsClient = new WebSocketClient($engine, $baseClient);
+    $endpoint = new LiveOrderBookEndpoint($wsClient);
+
+    // Mixed case should still resolve
+    $endpoint->listen('Thb_Btc', function () {});
+
+    expect($wsClient->getListeners())->toHaveKey('orderbook/1');
+});
+
+it('supports array of listeners', function () {
+    $engine = new MockWebSocketEngine;
+    $client = new WebSocketClient($engine);
+    $endpoint = new LiveOrderBookEndpoint($client);
+
+    $endpoint->listen(1, [
+        function () {},
+        function () {},
+    ]);
+
+    expect($client->getListeners())->toHaveKey('orderbook/1');
+    expect($client->getListeners()['orderbook/1'])->toHaveCount(2);
+});

--- a/tests/WebSocketTests/MarketEndpointTest.php
+++ b/tests/WebSocketTests/MarketEndpointTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use Farzai\Bitkub\Tests\WebSocketTests\MockWebSocketEngine;
+use Farzai\Bitkub\WebSocket\Endpoints\MarketEndpoint;
+use Farzai\Bitkub\WebSocketClient;
+
+it('throws InvalidArgumentException for invalid stream name', function () {
+    $engine = new MockWebSocketEngine;
+    $client = new WebSocketClient($engine);
+    $endpoint = new MarketEndpoint($client);
+
+    $endpoint->listen('invalid!!!', function () {});
+})->throws(\InvalidArgumentException::class, 'Invalid stream name format.');
+
+it('normalizes stream with and without market. prefix', function () {
+    $engine = new MockWebSocketEngine;
+    $client = new WebSocketClient($engine);
+    $endpoint = new MarketEndpoint($client);
+
+    $endpoint->listen('trade.thb_btc', function () {});
+    $endpoint->listen('market.trade.thb_btc', function () {});
+
+    $listeners = $client->getListeners();
+    expect($listeners)->toHaveCount(1);
+    expect($listeners['market.trade.thb_btc'])->toHaveCount(2);
+});
+
+it('listen returns static for chaining', function () {
+    $engine = new MockWebSocketEngine;
+    $client = new WebSocketClient($engine);
+    $endpoint = new MarketEndpoint($client);
+
+    $result = $endpoint->listen('trade.thb_btc', function () {});
+
+    expect($result)->toBe($endpoint);
+});
+
+it('supports comma-separated stream names as string', function () {
+    $engine = new MockWebSocketEngine;
+    $client = new WebSocketClient($engine);
+    $endpoint = new MarketEndpoint($client);
+
+    $endpoint->listen('trade.thb_btc, trade.thb_eth', function () {});
+
+    $listeners = $client->getListeners();
+    expect($listeners)->toHaveCount(2);
+    expect($listeners)->toHaveKey('market.trade.thb_btc');
+    expect($listeners)->toHaveKey('market.trade.thb_eth');
+});

--- a/tests/WebSocketTests/MarketEndpointTest.php
+++ b/tests/WebSocketTests/MarketEndpointTest.php
@@ -49,3 +49,44 @@ it('supports comma-separated stream names as string', function () {
     expect($listeners)->toHaveKey('market.trade.thb_btc');
     expect($listeners)->toHaveKey('market.trade.thb_eth');
 });
+
+it('filters empty entries from comma-separated string', function () {
+    $engine = new MockWebSocketEngine;
+    $client = new WebSocketClient($engine);
+    $endpoint = new MarketEndpoint($client);
+
+    $endpoint->listen('trade.thb_btc,,, trade.thb_eth,', function () {});
+
+    $listeners = $client->getListeners();
+    expect($listeners)->toHaveCount(2);
+    expect($listeners)->toHaveKey('market.trade.thb_btc');
+    expect($listeners)->toHaveKey('market.trade.thb_eth');
+});
+
+it('supports array of listeners', function () {
+    $engine = new MockWebSocketEngine;
+    $client = new WebSocketClient($engine);
+    $endpoint = new MarketEndpoint($client);
+
+    $endpoint->listen('trade.thb_btc', [
+        function () {},
+        function () {},
+    ]);
+
+    $listeners = $client->getListeners();
+    expect($listeners)->toHaveCount(1);
+    expect($listeners['market.trade.thb_btc'])->toHaveCount(2);
+});
+
+it('handles stream names with whitespace trimming', function () {
+    $engine = new MockWebSocketEngine;
+    $client = new WebSocketClient($engine);
+    $endpoint = new MarketEndpoint($client);
+
+    $endpoint->listen('  trade.thb_btc  ,  trade.thb_eth  ', function () {});
+
+    $listeners = $client->getListeners();
+    expect($listeners)->toHaveCount(2);
+    expect($listeners)->toHaveKey('market.trade.thb_btc');
+    expect($listeners)->toHaveKey('market.trade.thb_eth');
+});

--- a/tests/WebSocketTests/MarketEndpointTest.php
+++ b/tests/WebSocketTests/MarketEndpointTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Farzai\Bitkub\Tests\WebSocketTests\MockWebSocketEngine;
 use Farzai\Bitkub\WebSocket\Endpoints\MarketEndpoint;
 use Farzai\Bitkub\WebSocketClient;

--- a/tests/WebSocketTests/MessageObjectTest.php
+++ b/tests/WebSocketTests/MessageObjectTest.php
@@ -103,3 +103,46 @@ it('accepts pre-decoded array and skips json_decode', function () {
     expect($message->json('price'))->toBe(42000);
     expect($message->getBody())->toBe($body);
 });
+
+it('offsetGet returns null for missing key', function () {
+    $body = json_encode(['event' => 'test']);
+    $message = new Message($body, Carbon::now()->toDateTimeImmutable());
+
+    expect($message['nonexistent'])->toBeNull();
+});
+
+it('offsetExists returns false for missing key', function () {
+    $body = json_encode(['event' => 'test']);
+    $message = new Message($body, Carbon::now()->toDateTimeImmutable());
+
+    expect($message->offsetExists('nonexistent'))->toBeFalse();
+});
+
+it('__get returns null for missing key', function () {
+    $body = json_encode(['event' => 'test']);
+    $message = new Message($body, Carbon::now()->toDateTimeImmutable());
+
+    expect($message->nonexistent)->toBeNull();
+});
+
+it('__isset returns false for missing key', function () {
+    $body = json_encode(['event' => 'test']);
+    $message = new Message($body, Carbon::now()->toDateTimeImmutable());
+
+    expect(isset($message->nonexistent))->toBeFalse();
+});
+
+it('json with key returns null on invalid json body', function () {
+    $body = 'not json';
+    $message = new Message($body, Carbon::now()->toDateTimeImmutable());
+
+    expect($message->json('somekey'))->toBeNull();
+});
+
+it('jsonSerialize returns same as toArray', function () {
+    $decoded = ['event' => 'trade', 'data' => [1, 2, 3]];
+    $body = json_encode($decoded);
+    $message = new Message($body, Carbon::now()->toDateTimeImmutable());
+
+    expect($message->jsonSerialize())->toBe($message->toArray());
+});

--- a/tests/WebSocketTests/MessageObjectTest.php
+++ b/tests/WebSocketTests/MessageObjectTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Farzai\Bitkub\WebSocket\Message;
 use Farzai\Support\Carbon;
 

--- a/tests/WebSocketTests/MessageObjectTest.php
+++ b/tests/WebSocketTests/MessageObjectTest.php
@@ -89,3 +89,15 @@ it('should throw BadMethodCallException on __unset', function () {
 
     unset($message->event);
 })->throws(\BadMethodCallException::class, 'Message is immutable.');
+
+it('accepts pre-decoded array and skips json_decode', function () {
+    $decoded = ['event' => 'trade', 'price' => 42000];
+    $body = json_encode($decoded);
+
+    $message = new Message($body, Carbon::now()->toDateTimeImmutable(), $decoded);
+
+    expect($message->json())->toBe($decoded);
+    expect($message->json('event'))->toBe('trade');
+    expect($message->json('price'))->toBe(42000);
+    expect($message->getBody())->toBe($body);
+});

--- a/tests/WebSocketTests/MessageObjectTest.php
+++ b/tests/WebSocketTests/MessageObjectTest.php
@@ -39,22 +39,7 @@ it('should return message object', function () {
 
     expect($message->json('data.0.0'))->toBe(121.82);
 
-    // Test setter
-    $message->event = 'askschanged';
-    expect($message->event)->toBe('askschanged');
-
-    $message['event'] = 'askschanged';
-    expect($message->event)->toBe('askschanged');
-
-    // Test unset
     expect(isset($message->event))->toBeTrue();
-
-    unset($message->event);
-    expect($message->event)->toBeNull();
-    expect(isset($message->event))->toBeFalse();
-
-    unset($message['pairing_id']);
-    expect($message->pairing_id)->toBeNull();
 });
 
 it('should return null if json is not valid', function () {
@@ -66,3 +51,41 @@ it('should return null if json is not valid', function () {
 
     expect($message->json())->toBeNull();
 });
+
+it('should return empty array from toArray when json is invalid', function () {
+    $body = 'invalid json';
+
+    $currentDateTime = Carbon::now();
+
+    $message = new Message($body, $currentDateTime->toDateTimeImmutable());
+
+    expect($message->toArray())->toBe([]);
+});
+
+it('should throw BadMethodCallException on offsetSet', function () {
+    $body = json_encode(['event' => 'test']);
+    $message = new Message($body, Carbon::now()->toDateTimeImmutable());
+
+    $message['event'] = 'changed';
+})->throws(\BadMethodCallException::class, 'Message is immutable.');
+
+it('should throw BadMethodCallException on offsetUnset', function () {
+    $body = json_encode(['event' => 'test']);
+    $message = new Message($body, Carbon::now()->toDateTimeImmutable());
+
+    unset($message['event']);
+})->throws(\BadMethodCallException::class, 'Message is immutable.');
+
+it('should throw BadMethodCallException on __set', function () {
+    $body = json_encode(['event' => 'test']);
+    $message = new Message($body, Carbon::now()->toDateTimeImmutable());
+
+    $message->event = 'changed';
+})->throws(\BadMethodCallException::class, 'Message is immutable.');
+
+it('should throw BadMethodCallException on __unset', function () {
+    $body = json_encode(['event' => 'test']);
+    $message = new Message($body, Carbon::now()->toDateTimeImmutable());
+
+    unset($message->event);
+})->throws(\BadMethodCallException::class, 'Message is immutable.');

--- a/tests/WebSocketTests/MockWebSocketEngine.php
+++ b/tests/WebSocketTests/MockWebSocketEngine.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Farzai\Bitkub\Tests\WebSocketTests;
+
+use Farzai\Bitkub\Contracts\WebSocketEngineInterface;
+use Farzai\Bitkub\WebSocket\Message;
+use Farzai\Support\Carbon;
+
+class MockWebSocketEngine implements WebSocketEngineInterface
+{
+    /** @var array<int, array{stream: string, data: array<string, mixed>}> */
+    private array $messages = [];
+
+    private bool $handled = false;
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function addMessage(string $stream, array $data): self
+    {
+        $this->messages[] = ['stream' => $stream, 'data' => $data];
+
+        return $this;
+    }
+
+    public function handle(array $listeners): void
+    {
+        $this->handled = true;
+
+        foreach ($this->messages as $queued) {
+            $stream = $queued['stream'];
+            if (! isset($listeners[$stream])) {
+                continue;
+            }
+
+            $payload = array_merge($queued['data'], ['stream' => $stream]);
+            $body = json_encode($payload);
+            $message = new Message($body, Carbon::now()->toDateTimeImmutable(), $payload);
+
+            foreach ($listeners[$stream] as $listener) {
+                $listener($message);
+            }
+        }
+    }
+
+    public function wasHandled(): bool
+    {
+        return $this->handled;
+    }
+}

--- a/tests/WebSocketTests/WebSocketClientBuilderTest.php
+++ b/tests/WebSocketTests/WebSocketClientBuilderTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use Farzai\Bitkub\ClientBuilder;
+use Farzai\Bitkub\Tests\WebSocketTests\MockWebSocketEngine;
+use Farzai\Bitkub\WebSocketClient;
+use Farzai\Bitkub\WebSocketClientBuilder;
+
+it('can create WebSocketClient via builder', function () {
+    $baseClient = ClientBuilder::create()
+        ->setCredentials('key', 'secret')
+        ->build();
+
+    $ws = WebSocketClientBuilder::create()
+        ->setClient($baseClient)
+        ->build();
+
+    expect($ws)->toBeInstanceOf(WebSocketClient::class);
+    expect($ws->getClient())->toBe($baseClient);
+});
+
+it('uses NullLogger when no logger set', function () {
+    $ws = WebSocketClientBuilder::create()
+        ->build();
+
+    expect($ws->getLogger())->toBeInstanceOf(\Psr\Log\NullLogger::class);
+});
+
+it('can set custom base URL', function () {
+    $ws = WebSocketClientBuilder::create()
+        ->setBaseUrl('wss://custom.example.com/ws/')
+        ->build();
+
+    expect($ws)->toBeInstanceOf(WebSocketClient::class);
+});
+
+it('can set custom engine for testing', function () {
+    $engine = new MockWebSocketEngine;
+
+    $ws = WebSocketClientBuilder::create()
+        ->setEngine($engine)
+        ->build();
+
+    expect($ws)->toBeInstanceOf(WebSocketClient::class);
+
+    $ws->run();
+
+    expect($engine->wasHandled())->toBeTrue();
+});
+
+it('throws when reconnect attempts is negative', function () {
+    WebSocketClientBuilder::create()
+        ->setReconnectAttempts(-1);
+})->throws(\InvalidArgumentException::class, 'Reconnect attempts must be greater than or equal to 0.');
+
+it('throws when reconnect delay is negative', function () {
+    WebSocketClientBuilder::create()
+        ->setReconnectDelayMs(-1);
+})->throws(\InvalidArgumentException::class, 'Reconnect delay must be greater than or equal to 0.');
+
+it('can set custom logger', function () {
+    $logger = new \Psr\Log\NullLogger;
+
+    $ws = WebSocketClientBuilder::create()
+        ->setLogger($logger)
+        ->build();
+
+    expect($ws->getLogger())->toBe($logger);
+});
+
+it('uses client logger when no explicit logger set', function () {
+    $baseClient = ClientBuilder::create()
+        ->setCredentials('key', 'secret')
+        ->build();
+
+    $ws = WebSocketClientBuilder::create()
+        ->setClient($baseClient)
+        ->build();
+
+    expect($ws->getLogger())->toBe($baseClient->getLogger());
+});

--- a/tests/WebSocketTests/WebSocketClientBuilderTest.php
+++ b/tests/WebSocketTests/WebSocketClientBuilderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Farzai\Bitkub\ClientBuilder;
 use Farzai\Bitkub\Tests\WebSocketTests\MockWebSocketEngine;
 use Farzai\Bitkub\WebSocketClient;

--- a/tests/WebSocketTests/WebSocketClientBuilderTest.php
+++ b/tests/WebSocketTests/WebSocketClientBuilderTest.php
@@ -80,3 +80,39 @@ it('uses client logger when no explicit logger set', function () {
 
     expect($ws->getLogger())->toBe($baseClient->getLogger());
 });
+
+it('allows zero reconnect attempts', function () {
+    $ws = WebSocketClientBuilder::create()
+        ->setReconnectAttempts(0)
+        ->build();
+
+    expect($ws)->toBeInstanceOf(WebSocketClient::class);
+});
+
+it('allows zero reconnect delay', function () {
+    $ws = WebSocketClientBuilder::create()
+        ->setReconnectDelayMs(0)
+        ->build();
+
+    expect($ws)->toBeInstanceOf(WebSocketClient::class);
+});
+
+it('can set reconnect attempts and delay with custom values', function () {
+    $engine = new MockWebSocketEngine;
+
+    $ws = WebSocketClientBuilder::create()
+        ->setEngine($engine)
+        ->setReconnectAttempts(5)
+        ->setReconnectDelayMs(2000)
+        ->build();
+
+    expect($ws)->toBeInstanceOf(WebSocketClient::class);
+});
+
+it('builder methods return static for chaining', function () {
+    $builder = WebSocketClientBuilder::create();
+
+    expect($builder->setBaseUrl('wss://example.com/'))->toBe($builder);
+    expect($builder->setReconnectAttempts(3))->toBe($builder);
+    expect($builder->setReconnectDelayMs(1000))->toBe($builder);
+});

--- a/tests/WebSocketTests/WebSocketClientTest.php
+++ b/tests/WebSocketTests/WebSocketClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Farzai\Bitkub\ClientBuilder;
 use Farzai\Bitkub\Tests\MockHttpClient;
 use Farzai\Bitkub\Tests\WebSocketTests\MockWebSocketEngine;

--- a/tests/WebSocketTests/WebSocketClientTest.php
+++ b/tests/WebSocketTests/WebSocketClientTest.php
@@ -2,30 +2,29 @@
 
 use Farzai\Bitkub\ClientBuilder;
 use Farzai\Bitkub\Tests\MockHttpClient;
+use Farzai\Bitkub\Tests\WebSocketTests\MockWebSocketEngine;
 use Farzai\Bitkub\WebSocket\Endpoints\AbstractEndpoint;
 use Farzai\Bitkub\WebSocket\Endpoints\LiveOrderBookEndpoint;
 use Farzai\Bitkub\WebSocket\Endpoints\MarketEndpoint;
 use Farzai\Bitkub\WebSocketClient;
+use Farzai\Bitkub\WebSocketClientBuilder;
 
-it('should create new instance of WebSocketClient', function () {
-    $client = new WebSocketClient(
-        $baseClient = ClientBuilder::create()
-            ->setCredentials('YOUR_API_KEY', 'YOUR_SECRET')
-            ->build()
-    );
+it('should create new instance of WebSocketClient via builder', function () {
+    $baseClient = ClientBuilder::create()
+        ->setCredentials('YOUR_API_KEY', 'YOUR_SECRET')
+        ->build();
 
-    expect($client)->toBeInstanceOf(WebSocketClient::class);
+    $ws = WebSocketClientBuilder::create()
+        ->setClient($baseClient)
+        ->build();
 
-    expect($client->getConfig())->toBe($baseClient->getConfig());
-    expect($client->getLogger())->toBe($baseClient->getLogger());
+    expect($ws)->toBeInstanceOf(WebSocketClient::class);
+    expect($ws->getConfig())->toBe($baseClient->getConfig());
 });
 
 it('should add listener success', function () {
-    $client = new WebSocketClient(
-        ClientBuilder::create()
-            ->setCredentials('YOUR_API_KEY', 'YOUR_SECRET')
-            ->build()
-    );
+    $engine = new MockWebSocketEngine;
+    $client = new WebSocketClient($engine);
 
     $client->addListener('market.trade.thb_btc', function () {
         //
@@ -43,11 +42,8 @@ it('should add listener success', function () {
 });
 
 it('should add listener with array', function () {
-    $client = new WebSocketClient(
-        ClientBuilder::create()
-            ->setCredentials('YOUR_API_KEY', 'YOUR_SECRET')
-            ->build()
-    );
+    $engine = new MockWebSocketEngine;
+    $client = new WebSocketClient($engine);
 
     $client->addListener('market.trade.thb_btc', [
         function () {
@@ -75,36 +71,30 @@ it('should add listener with array', function () {
 });
 
 it('should call run on endpoint success', function () {
-    $client = $this->createMock(WebSocketClient::class);
-    $client->expects($this->once())->method('run');
+    $engine = new MockWebSocketEngine;
+    $client = new WebSocketClient($engine);
 
     $endpoint = new MarketEndpoint($client);
 
     expect($endpoint)->toBeInstanceOf(AbstractEndpoint::class);
 
     $endpoint->run();
+
+    expect($engine->wasHandled())->toBeTrue();
 });
 
-it('should call handle on client success', function () {
+it('should call handle on engine when run is invoked', function () {
     $engine = $this->createMock(\Farzai\Bitkub\Contracts\WebSocketEngineInterface::class);
     $engine->expects($this->once())->method('handle');
 
-    $client = new WebSocketClient(
-        ClientBuilder::create()
-            ->setCredentials('YOUR_API_KEY', 'YOUR_SECRET')
-            ->build(),
-        $engine,
-    );
+    $client = new WebSocketClient($engine);
 
     $client->run();
 });
 
 it('should create new instance of market endpoint', function () {
-    $client = new WebSocketClient(
-        ClientBuilder::create()
-            ->setCredentials('YOUR_API_KEY', 'YOUR_SECRET')
-            ->build()
-    );
+    $engine = new MockWebSocketEngine;
+    $client = new WebSocketClient($engine);
 
     $endpoint = new MarketEndpoint($client);
 
@@ -112,11 +102,8 @@ it('should create new instance of market endpoint', function () {
 });
 
 it('can put stream name as string success', function () {
-    $client = new WebSocketClient(
-        ClientBuilder::create()
-            ->setCredentials('YOUR_API_KEY', 'YOUR_SECRET')
-            ->build()
-    );
+    $engine = new MockWebSocketEngine;
+    $client = new WebSocketClient($engine);
 
     $endpoint = new MarketEndpoint($client);
 
@@ -136,11 +123,8 @@ it('can put stream name as string success', function () {
 });
 
 it('can put stream name with array success', function () {
-    $client = new WebSocketClient(
-        ClientBuilder::create()
-            ->setCredentials('YOUR_API_KEY', 'YOUR_SECRET')
-            ->build()
-    );
+    $engine = new MockWebSocketEngine;
+    $client = new WebSocketClient($engine);
 
     $endpoint = new MarketEndpoint($client);
 
@@ -168,11 +152,8 @@ it('can put stream name with array success', function () {
 });
 
 it('should create live order book endpoint success', function () {
-    $client = new WebSocketClient(
-        ClientBuilder::create()
-            ->setCredentials('YOUR_API_KEY', 'YOUR_SECRET')
-            ->build()
-    );
+    $engine = new MockWebSocketEngine;
+    $client = new WebSocketClient($engine);
 
     $endpoint = new LiveOrderBookEndpoint($client);
 
@@ -180,11 +161,8 @@ it('should create live order book endpoint success', function () {
 });
 
 it('can put symbol by id success', function () {
-    $client = new WebSocketClient(
-        ClientBuilder::create()
-            ->setCredentials('YOUR_API_KEY', 'YOUR_SECRET')
-            ->build()
-    );
+    $engine = new MockWebSocketEngine;
+    $client = new WebSocketClient($engine);
 
     $endpoint = new LiveOrderBookEndpoint($client);
 
@@ -225,12 +203,13 @@ it('can put symbol by name success', function () {
         ->addSequence(MockHttpClient::response(200, json_encode($symbolResponseBody)))
         ->addSequence(MockHttpClient::response(200, json_encode($symbolResponseBody)));
 
-    $client = new WebSocketClient(
-        ClientBuilder::create()
-            ->setCredentials('YOUR_API_KEY', 'YOUR_SECRET')
-            ->setHttpClient($httpClient)
-            ->build()
-    );
+    $baseClient = ClientBuilder::create()
+        ->setCredentials('YOUR_API_KEY', 'YOUR_SECRET')
+        ->setHttpClient($httpClient)
+        ->build();
+
+    $engine = new MockWebSocketEngine;
+    $client = new WebSocketClient($engine, $baseClient);
 
     $endpoint = new LiveOrderBookEndpoint($client);
 
@@ -277,12 +256,13 @@ it('should throw error if invalid symbol name', function () {
     $httpClient = MockHttpClient::make()
         ->addSequence(MockHttpClient::response(200, json_encode($symbolResponseBody)));
 
-    $client = new WebSocketClient(
-        ClientBuilder::create()
-            ->setCredentials('YOUR_API_KEY', 'YOUR_SECRET')
-            ->setHttpClient($httpClient)
-            ->build()
-    );
+    $baseClient = ClientBuilder::create()
+        ->setCredentials('YOUR_API_KEY', 'YOUR_SECRET')
+        ->setHttpClient($httpClient)
+        ->build();
+
+    $engine = new MockWebSocketEngine;
+    $client = new WebSocketClient($engine, $baseClient);
 
     $endpoint = new LiveOrderBookEndpoint($client);
 
@@ -290,3 +270,32 @@ it('should throw error if invalid symbol name', function () {
         //
     });
 })->throws(\InvalidArgumentException::class, 'Invalid symbol name. Given: thb_xxx');
+
+it('returns same market endpoint instance (lazy singleton)', function () {
+    $engine = new MockWebSocketEngine;
+    $client = new WebSocketClient($engine);
+
+    $first = $client->market();
+    $second = $client->market();
+
+    expect($first)->toBe($second);
+});
+
+it('returns same liveOrderBook endpoint instance (lazy singleton)', function () {
+    $engine = new MockWebSocketEngine;
+    $client = new WebSocketClient($engine);
+
+    $first = $client->liveOrderBook();
+    $second = $client->liveOrderBook();
+
+    expect($first)->toBe($second);
+});
+
+it('addListener returns static for chaining', function () {
+    $engine = new MockWebSocketEngine;
+    $client = new WebSocketClient($engine);
+
+    $result = $client->addListener('test', function () {});
+
+    expect($result)->toBe($client);
+});

--- a/tests/WebSocketTests/WebSocketClientTest.php
+++ b/tests/WebSocketTests/WebSocketClientTest.php
@@ -301,3 +301,43 @@ it('addListener returns static for chaining', function () {
 
     expect($result)->toBe($client);
 });
+
+it('getConfig returns empty array when no client set', function () {
+    $engine = new MockWebSocketEngine;
+    $client = new WebSocketClient($engine);
+
+    expect($client->getConfig())->toBe([]);
+});
+
+it('getClient returns null when no client set', function () {
+    $engine = new MockWebSocketEngine;
+    $client = new WebSocketClient($engine);
+
+    expect($client->getClient())->toBeNull();
+});
+
+it('getLogger returns NullLogger when no logger or client set', function () {
+    $engine = new MockWebSocketEngine;
+    $client = new WebSocketClient($engine);
+
+    expect($client->getLogger())->toBeInstanceOf(\Psr\Log\NullLogger::class);
+});
+
+it('getLogger returns explicit logger when set', function () {
+    $engine = new MockWebSocketEngine;
+    $logger = new \Psr\Log\NullLogger;
+    $client = new WebSocketClient($engine, null, $logger);
+
+    expect($client->getLogger())->toBe($logger);
+});
+
+it('getLogger falls back to client logger when no explicit logger', function () {
+    $baseClient = ClientBuilder::create()
+        ->setCredentials('key', 'secret')
+        ->build();
+
+    $engine = new MockWebSocketEngine;
+    $client = new WebSocketClient($engine, $baseClient);
+
+    expect($client->getLogger())->toBe($baseClient->getLogger());
+});


### PR DESCRIPTION
## Summary

Major quality and reliability overhaul for the Bitkub PHP SDK — enforces strict typing across all files, fixes several API and data-handling bugs, refactors the WebSocket client with a builder pattern, and significantly expands test coverage.

### Breaking Changes

- **`Message` class is now immutable** — `offsetSet`, `offsetUnset`, `__set`, and `__unset` throw `BadMethodCallException`
- **`PendingRequest` properties changed from `public` to `private`** — use accessor methods instead
- **`WebSocketClient` constructor signature changed** — accepts engine and optional HTTP client; use `WebSocketClientBuilder` for configuration
- **`LiveOrderBookEndpoint` symbol map is now an instance property** instead of static

### Bug Fixes

- Fix `array_filter` usage with explicit callbacks to prevent filtering out valid falsy values (e.g., `0`)
- Fix `my-open-orders` endpoint to send `sym` as query param instead of request body (matches Bitkub API v3 spec)
- Fix `BitkubResponseErrorCodeException` to handle missing error codes gracefully instead of throwing raw exceptions
- Replace `@json_decode` with proper validation (`is_array` checks)
- Fix README typos and incorrect API path for wallet endpoint (`GET` → `POST /api/v3/market/wallet`)

### Improvements

- Add `declare(strict_types=1)` and return type declarations across all PHP files
- Cache endpoint instances, server timestamp drift, and symbol map to reduce redundant HTTP calls
- Add `WebSocketClientBuilder` for fluent WebSocket client configuration
- Add reconnection logic with configurable attempts to WebSocket Engine
- Improve WebSocket stream name validation with regex
- Improve type hints and PHPDoc annotations across WebSocket components

### CI/CD

- Restrict code style workflow to `main` branch only
- Fix dependabot auto-merge workflow trigger (`pull_request_target` → `pull_request`)
- Set `minimum-stability` to `stable` in `composer.json`

### Documentation

- Fix WebSocket examples to use `WebSocketClientBuilder`
- Add `LiveOrderBook` endpoint documentation
- Add PHP 8.2+ requirement badge to README

### Tests

- Add tests for `GenerateSignatureV3` (header attachment, timestamp caching, HMAC computation)
- Add tests for market order endpoints (`openOrders`, `myOrderHistory`, `myOrderInfo`)
- Add tests for immutable `Message` behavior and `ResponseWithValidateErrorCode` custom callbacks
- Add `MockHttpClient` request recording for better test assertions
- Add `MockWebSocketEngine` and tests for Engine, endpoints, and builder
- Refactor existing WebSocket tests to use mock engine

## Test Plan

- [ ] Run `composer test` — all existing and new tests pass
- [ ] Verify `GenerateSignatureV3` timestamp caching reduces server time API calls
- [ ] Verify `Message` immutability throws `BadMethodCallException` on mutation
- [ ] Verify `array_filter` fix preserves valid falsy values (e.g., `0`)
- [ ] Verify `my-open-orders` sends `sym` as query param (not body)
- [ ] Verify `WebSocketClientBuilder` produces correctly configured clients